### PR TITLE
Make setscalar GPU-friendly

### DIFF
--- a/src/sizes.jl
+++ b/src/sizes.jl
@@ -46,7 +46,12 @@ function _getscalar(x, sizes::Sizes, k::Int)
 end
 
 function _setscalar!(x, value, sizes::Sizes, k::Int)
-    return x[sizes.storage_offset[k]+1] = value
+    # Use a 1-element view + broadcast so this works on GPU storage as well as
+    # `Vector{Float64}`. Direct `x[idx] = value` is a scalar setindex which
+    # GPUArrays disallows by default.
+    pos = sizes.storage_offset[k] + 1
+    view(x, pos:pos) .= value
+    return value
 end
 
 """

--- a/src/sizes.jl
+++ b/src/sizes.jl
@@ -49,8 +49,8 @@ function _setscalar!(x, value, sizes::Sizes, k::Int)
     # Use a 1-element view + broadcast so this works on GPU storage as well as
     # `Vector{Float64}`. Direct `x[idx] = value` is a scalar setindex which
     # GPUArrays disallows by default.
-    pos = sizes.storage_offset[k] + 1
-    view(x, pos:pos) .= value
+    pos = _scalar_pos(sizes, k)
+    view(x, reshape(pos:pos, ())) .= value
     return value
 end
 


### PR DESCRIPTION
On CPU, it makes no difference:
```julia
using BenchmarkTools

function _setindex1!(x, v, i)
    x[i] = v
    return
end

function _setindex2!(x, v, i)
    I = reshape(i:i, ())
    view(x, I) .= v
    return
end

function _setindex3!(x, v, i)
    I = i:i
    view(x, I) .= v
    return
end

function setindex_bench()
    x = rand(10)
    i = 3
    v = 2.0
    @btime _setindex1!($x, $v, $i)
    @btime _setindex2!($x, $v, $i)
    @btime _setindex3!($x, $v, $i)
end

setindex_bench()
setindex_bench()
setindex_bench()
setindex_bench()
```
gives
```
  2.075 ns (0 allocations: 0 bytes)
  2.091 ns (0 allocations: 0 bytes)
  2.046 ns (0 allocations: 0 bytes)

  1.937 ns (0 allocations: 0 bytes)
  2.089 ns (0 allocations: 0 bytes)
  2.089 ns (0 allocations: 0 bytes)

  2.050 ns (0 allocations: 0 bytes)
  2.048 ns (0 allocations: 0 bytes)
  2.085 ns (0 allocations: 0 bytes)

  2.088 ns (0 allocations: 0 bytes)
  2.047 ns (0 allocations: 0 bytes)
  2.046 ns (0 allocations: 0 bytes)
```
But since CUDA disallow scalar indexing, this is a way to make CUDA not complain without needed to write `CUDA.@allowscalar`.