### PR TITLE
Fix broadcast with scalar

### DIFF
--- a/src/JuMP/moi_bridge.jl
+++ b/src/JuMP/moi_bridge.jl
@@ -12,7 +12,7 @@ function _to_moi_arg(x::GenericArrayExpr{V,N}) where {V,N}
     return ArrayNonlinearFunction{N}(x.head, args, x.size, x.broadcasted)
 end
 
-_to_moi_arg(x::Matrix{<:Real}) = x
+_to_moi_arg(x::Array{<:Real}) = x
 
 _to_moi_arg(x::Real) = x
 

--- a/src/reverse_mode.jl
+++ b/src/reverse_mode.jl
@@ -391,14 +391,24 @@ function _forward_eval(
             children_indices = SparseArrays.nzrange(f.adj, k)
             N = length(children_indices)
             if node.index == 1 # :+  (broadcasted)
-                for j in _eachindex(f.sizes, k)
-                    tmp_sum = zero(T)
-                    for c_idx in children_indices
-                        ix = children_arr[c_idx]
-                        @j f.partials_storage[ix] = one(T)
-                        tmp_sum += @j f.forward_storage[ix]
+                # Broadcast-aware sum: scalar children contribute their
+                # single value to every output slot.
+                out = _view_linear(f.forward_storage, f.sizes, k)
+                fill!(out, zero(T))
+                for c_idx in children_indices
+                    ix = children_arr[c_idx]
+                    if f.sizes.ndims[ix] == 0
+                        s = _getscalar(f.forward_storage, f.sizes, ix)
+                        out .+= s
+                        _setscalar!(f.partials_storage, one(T), f.sizes, ix)
+                    else
+                        v = _view_linear(f.forward_storage, f.sizes, ix)
+                        out .+= v
+                        fill!(
+                            _view_linear(f.partials_storage, f.sizes, ix),
+                            one(T),
+                        )
                     end
-                    @j f.forward_storage[k] = tmp_sum
                 end
             elseif node.index == 2 # :-  (broadcasted)
                 @assert N == 2
@@ -406,31 +416,82 @@ function _forward_eval(
                 @inbounds ix1 = children_arr[child1]
                 @inbounds ix2 = children_arr[child1+1]
                 out = _view_linear(f.forward_storage, f.sizes, k)
-                v1 = _view_linear(f.forward_storage, f.sizes, ix1)
-                v2 = _view_linear(f.forward_storage, f.sizes, ix2)
-                out .= v1 .- v2
-                fill!(_view_linear(f.partials_storage, f.sizes, ix1), one(T))
-                fill!(_view_linear(f.partials_storage, f.sizes, ix2), -one(T))
+                ndims1 = f.sizes.ndims[ix1]
+                ndims2 = f.sizes.ndims[ix2]
+                if ndims1 == 0 && ndims2 != 0
+                    s1 = _getscalar(f.forward_storage, f.sizes, ix1)
+                    v2 = _view_linear(f.forward_storage, f.sizes, ix2)
+                    out .= s1 .- v2
+                    _setscalar!(f.partials_storage, one(T), f.sizes, ix1)
+                    fill!(
+                        _view_linear(f.partials_storage, f.sizes, ix2),
+                        -one(T),
+                    )
+                elseif ndims1 != 0 && ndims2 == 0
+                    v1 = _view_linear(f.forward_storage, f.sizes, ix1)
+                    s2 = _getscalar(f.forward_storage, f.sizes, ix2)
+                    out .= v1 .- s2
+                    fill!(
+                        _view_linear(f.partials_storage, f.sizes, ix1),
+                        one(T),
+                    )
+                    _setscalar!(f.partials_storage, -one(T), f.sizes, ix2)
+                else
+                    v1 = _view_linear(f.forward_storage, f.sizes, ix1)
+                    v2 = _view_linear(f.forward_storage, f.sizes, ix2)
+                    out .= v1 .- v2
+                    fill!(
+                        _view_linear(f.partials_storage, f.sizes, ix1),
+                        one(T),
+                    )
+                    fill!(
+                        _view_linear(f.partials_storage, f.sizes, ix2),
+                        -one(T),
+                    )
+                end
             elseif node.index == 3 # :*  (broadcasted)
-                # Node `k` is not scalar, so we do matrix multiplication
+                # Node `k` is not scalar, so we do element-wise multiply
+                # (with scalar-broadcast support: when one operand is
+                # scalar, broadcast it across the matrix output).
                 if f.sizes.ndims[k] != 0
                     @assert N == 2
                     idx1 = first(children_indices)
                     idx2 = last(children_indices)
                     @inbounds ix1 = children_arr[idx1]
                     @inbounds ix2 = children_arr[idx2]
-                    v1 = zeros(_size(f.sizes, ix1)...)
-                    v2 = zeros(_size(f.sizes, ix2)...)
-                    for j in _eachindex(f.sizes, ix1)
-                        v1[j] = @j f.forward_storage[ix1]
-                        @j f.partials_storage[ix2] = v1[j]
-                    end
-                    for j in _eachindex(f.sizes, ix2)
-                        v2[j] = @j f.forward_storage[ix2]
-                        @j f.partials_storage[ix1] = v2[j]
-                    end
-                    for j in _eachindex(f.sizes, k)
-                        @j f.forward_storage[k] = v1[j] * v2[j]
+                    out = _view_linear(f.forward_storage, f.sizes, k)
+                    ndims1 = f.sizes.ndims[ix1]
+                    ndims2 = f.sizes.ndims[ix2]
+                    if ndims1 == 0 && ndims2 != 0
+                        s = _getscalar(f.forward_storage, f.sizes, ix1)
+                        v = _view_linear(f.forward_storage, f.sizes, ix2)
+                        out .= s .* v
+                        # Per-element partial w.r.t. the matrix child is
+                        # the scalar; the scalar child's reverse is handled
+                        # by the broadcasted-`:*` reverse branch below
+                        # (sum of `rev_parent .* v`).
+                        fill!(_view_linear(f.partials_storage, f.sizes, ix2), s)
+                    elseif ndims1 != 0 && ndims2 == 0
+                        v = _view_linear(f.forward_storage, f.sizes, ix1)
+                        s = _getscalar(f.forward_storage, f.sizes, ix2)
+                        out .= v .* s
+                        fill!(_view_linear(f.partials_storage, f.sizes, ix1), s)
+                    else
+                        # Both children are arrays of the same shape —
+                        # original element-wise path.
+                        v1 = zeros(_size(f.sizes, ix1)...)
+                        v2 = zeros(_size(f.sizes, ix2)...)
+                        for j in _eachindex(f.sizes, ix1)
+                            v1[j] = @j f.forward_storage[ix1]
+                            @j f.partials_storage[ix2] = v1[j]
+                        end
+                        for j in _eachindex(f.sizes, ix2)
+                            v2[j] = @j f.forward_storage[ix2]
+                            @j f.partials_storage[ix1] = v2[j]
+                        end
+                        for j in _eachindex(f.sizes, k)
+                            @j f.forward_storage[k] = v1[j] * v2[j]
+                        end
                     end
                     # Node `k` is scalar
                 else
@@ -832,13 +893,80 @@ function _reverse_eval(
         elseif node.type == NODE_CALL_MULTIVARIATE_BROADCASTED
             if node.index in eachindex(DEFAULT_MULTIVARIATE_OPERATORS)
                 op = DEFAULT_MULTIVARIATE_OPERATORS[node.index]
+                # Broadcasted +/- with at least one scalar child: the
+                # scalar's reverse is the (signed) sum of the parent's
+                # adjoint over the broadcast positions. Handle both scalar
+                # and matrix children here so the generic
+                # diagonal-partial path below doesn't trip its
+                # `_size(k) == _size(ix)` assertion.
+                if (op == :+ || op == :-) &&
+                   any(
+                       c -> f.sizes.ndims[children_arr[c]] == 0,
+                       children_indices,
+                   ) &&
+                   f.sizes.ndims[k] != 0
+                    Tr = eltype(f.reverse_storage)
+                    rev_parent = _view_linear(f.reverse_storage, f.sizes, k)
+                    for c_idx in children_indices
+                        ix = children_arr[c_idx]
+                        # `:-` flips the sign for the second operand, mirroring
+                        # the partial we wrote in the forward pass.
+                        partial_sign =
+                            (op == :- && c_idx != first(children_indices)) ?
+                            -one(Tr) : one(Tr)
+                        if f.sizes.ndims[ix] == 0
+                            _setscalar!(
+                                f.reverse_storage,
+                                partial_sign * sum(rev_parent),
+                                f.sizes,
+                                ix,
+                            )
+                        else
+                            rev_child =
+                                _view_linear(f.reverse_storage, f.sizes, ix)
+                            rev_child .= partial_sign .* rev_parent
+                        end
+                    end
+                    continue
+                end
                 if op == :*
                     if f.sizes.ndims[k] != 0
-                        # Node `k` is not scalar, so we do matrix multiplication or broadcasted multiplication
                         idx1 = first(children_indices)
                         idx2 = last(children_indices)
                         ix1 = children_arr[idx1]
                         ix2 = children_arr[idx2]
+                        rev_parent = _view_linear(f.reverse_storage, f.sizes, k)
+                        ndims1 = f.sizes.ndims[ix1]
+                        ndims2 = f.sizes.ndims[ix2]
+                        if ndims1 == 0 && ndims2 != 0
+                            v2 = _view_linear(f.forward_storage, f.sizes, ix2)
+                            s1 = _getscalar(f.forward_storage, f.sizes, ix1)
+                            rev_v2 =
+                                _view_linear(f.reverse_storage, f.sizes, ix2)
+                            rev_v2 .= rev_parent .* s1
+                            _setscalar!(
+                                f.reverse_storage,
+                                LinearAlgebra.dot(rev_parent, v2),
+                                f.sizes,
+                                ix1,
+                            )
+                            continue
+                        elseif ndims1 != 0 && ndims2 == 0
+                            v1 = _view_linear(f.forward_storage, f.sizes, ix1)
+                            s2 = _getscalar(f.forward_storage, f.sizes, ix2)
+                            rev_v1 =
+                                _view_linear(f.reverse_storage, f.sizes, ix1)
+                            rev_v1 .= rev_parent .* s2
+                            _setscalar!(
+                                f.reverse_storage,
+                                LinearAlgebra.dot(rev_parent, v1),
+                                f.sizes,
+                                ix2,
+                            )
+                            continue
+                        end
+                        # Both children are arrays of the same shape —
+                        # original element-wise path.
                         v1 = zeros(_size(f.sizes, ix1)...)
                         v2 = zeros(_size(f.sizes, ix2)...)
                         for j in _eachindex(f.sizes, ix1)

--- a/src/reverse_mode.jl
+++ b/src/reverse_mode.jl
@@ -84,7 +84,7 @@ function _reverse_mode(d::NLPEvaluator, x)
 end
 
 function _forward_broadcasted(
-    ::typeof(+),
+    op::Union{typeof(+),typeof(-)},
     f::_SubexpressionStorage,
     d::NLPEvaluator,
     x::AbstractVector,
@@ -92,7 +92,8 @@ function _forward_broadcasted(
     lhs,
     rhs,
 )
-    return out .= lhs .+ rhs
+    broadcast!(op, out, lhs, rhs)
+    return
 end
 
 function _reshape_forward_broadcasted(::Tuple{}, args...)
@@ -473,42 +474,29 @@ function _forward_eval(
             elseif node.index == 2 # :-  (broadcasted)
                 @assert N == 2
                 child1 = first(children_indices)
-                @inbounds ix1 = children_arr[child1]
-                @inbounds ix2 = children_arr[child1+1]
-                out = _view_linear(f.forward_storage, f.sizes, k)
-                ndims1 = f.sizes.ndims[ix1]
-                ndims2 = f.sizes.ndims[ix2]
-                if ndims1 == 0 && ndims2 != 0
-                    s1 = _getscalar(f.forward_storage, f.sizes, ix1)
-                    v2 = _view_linear(f.forward_storage, f.sizes, ix2)
-                    out .= s1 .- v2
-                    _setscalar!(f.partials_storage, one(T), f.sizes, ix1)
-                    fill!(
-                        _view_linear(f.partials_storage, f.sizes, ix2),
-                        -one(T),
-                    )
-                elseif ndims1 != 0 && ndims2 == 0
-                    v1 = _view_linear(f.forward_storage, f.sizes, ix1)
-                    s2 = _getscalar(f.forward_storage, f.sizes, ix2)
-                    out .= v1 .- s2
-                    fill!(
-                        _view_linear(f.partials_storage, f.sizes, ix1),
-                        one(T),
-                    )
-                    _setscalar!(f.partials_storage, -one(T), f.sizes, ix2)
-                else
-                    v1 = _view_linear(f.forward_storage, f.sizes, ix1)
-                    v2 = _view_linear(f.forward_storage, f.sizes, ix2)
-                    out .= v1 .- v2
-                    fill!(
-                        _view_linear(f.partials_storage, f.sizes, ix1),
-                        one(T),
-                    )
-                    fill!(
-                        _view_linear(f.partials_storage, f.sizes, ix2),
-                        -one(T),
-                    )
-                end
+                _reshape_forward_broadcasted(
+                    (k, children_arr[child1], children_arr[child1+1]),
+                    -,
+                    f,
+                    d,
+                    x,
+                )
+                fill!(
+                    _view_linear(
+                        f.partials_storage,
+                        f.sizes,
+                        children_arr[child1],
+                    ),
+                    one(T),
+                )
+                fill!(
+                    _view_linear(
+                        f.partials_storage,
+                        f.sizes,
+                        children_arr[child1+1],
+                    ),
+                    -one(T),
+                )
             elseif node.index == 3 # :*  (broadcasted)
                 # Node `k` is not scalar, so we do element-wise multiply
                 # (with scalar-broadcast support: when one operand is

--- a/src/reverse_mode.jl
+++ b/src/reverse_mode.jl
@@ -820,44 +820,46 @@ function _reverse_eval(
                 # and matrix children here so the generic
                 # diagonal-partial path below doesn't trip its
                 # `_size(k) == _size(ix)` assertion.
-                if op == :+ || op == :-
+                if op == :+ || op == :- || op == :*
                     @assert length(children_indices) == 2
                     child1 = first(children_indices)
-                    _reshape_call(
-                        f.reverse_storage,
-                        f.sizes,
-                        (children_arr[child1], k),
-                        sum!,
-                    )
+                    lhs = children_arr[child1]
                     rhs = children_arr[child1+1]
-                    if op == :+
+                    if op == :*
                         _reshape_call(
                             f.reverse_storage,
                             f.sizes,
-                            (rhs, k),
-                            sum!,
+                            (k, lhs, rhs),
+                            __reverse_broadcasted_mul,
+                            f,
+                            lhs,
+                            rhs,
                         )
-                    elseif op == :-
+                    else
                         _reshape_call(
                             f.reverse_storage,
                             f.sizes,
-                            (rhs, k),
+                            (children_arr[child1], k),
                             sum!,
-                            -,
                         )
+                        rhs = children_arr[child1+1]
+                        if op == :+
+                            _reshape_call(
+                                f.reverse_storage,
+                                f.sizes,
+                                (rhs, k),
+                                sum!,
+                            )
+                        elseif op == :-
+                            _reshape_call(
+                                f.reverse_storage,
+                                f.sizes,
+                                (rhs, k),
+                                sum!,
+                                -,
+                            )
+                        end
                     end
-                    continue
-                end
-                if op == :*
-                    _reshape_call(
-                        f.reverse_storage,
-                        f.sizes,
-                        (k, lhs, rhs),
-                        __reverse_broadcasted_mul,
-                        f,
-                        lhs,
-                        rhs,
-                    )
                     continue
                 end
             end

--- a/src/reverse_mode.jl
+++ b/src/reverse_mode.jl
@@ -455,22 +455,6 @@ function _forward_eval(
                     broadcast!,
                     +,
                 )
-                fill!(
-                    _view_linear(
-                        f.partials_storage,
-                        f.sizes,
-                        children_arr[child1],
-                    ),
-                    one(T),
-                )
-                fill!(
-                    _view_linear(
-                        f.partials_storage,
-                        f.sizes,
-                        children_arr[child1+1],
-                    ),
-                    one(T),
-                )
             elseif node.index == 2 # :-  (broadcasted)
                 @assert N == 2
                 child1 = first(children_indices)

--- a/src/reverse_mode.jl
+++ b/src/reverse_mode.jl
@@ -96,40 +96,44 @@ function _forward_broadcasted(
     return
 end
 
-function _reshape_call(::_SubexpressionStorage, ::Tuple{}, op, args...)
+function _reshape_call(_, _::Sizes, ::Tuple{}, op, args...)
     return op(args...)
 end
 
-function _reshape_call(f, nodes::Tuple, args...)
+function _reshape_call(storage, sizes::Sizes, nodes::Tuple, args...)
     node = first(nodes)
-    ndims = f.sizes.ndims[node]
+    ndims = sizes.ndims[node]
     if ndims == 0
         _reshape_call(
-            f,
+            storage,
+            sizes,
             Base.tail(nodes),
             args...,
-            _getscalar(f.forward_storage, f.sizes, node),
+            _view_scalar(storage, sizes, node),
         )
     elseif ndims == 1
         _reshape_call(
-            f,
+            storage,
+            sizes,
             Base.tail(nodes),
             args...,
-            _view_linear(f.forward_storage, f.sizes, node),
+            _view_linear(storage, sizes, node),
         )
     elseif ndims == 2
         _reshape_call(
-            f,
+            storage,
+            sizes,
             Base.tail(nodes),
             args...,
-            _view_matrix(f.forward_storage, f.sizes, node),
+            _view_matrix(storage, sizes, node),
         )
     else
         _reshape_call(
-            f,
+            storage,
+            sizes,
             Base.tail(nodes),
             args...,
-            _view_array(f.forward_storage, f.sizes, node),
+            _view_array(storage, sizes, node),
         )
     end
 end
@@ -445,7 +449,8 @@ function _forward_eval(
                 @assert N == 2
                 child1 = first(children_indices)
                 _reshape_call(
-                    f,
+                    f.forward_storage,
+                    f.sizes,
                     (k, children_arr[child1], children_arr[child1+1]),
                     broadcast!,
                     +,
@@ -470,7 +475,8 @@ function _forward_eval(
                 @assert N == 2
                 child1 = first(children_indices)
                 _reshape_call(
-                    f,
+                    f.forward_storage,
+                    f.sizes,
                     (k, children_arr[child1], children_arr[child1+1]),
                     broadcast!,
                     -,
@@ -941,33 +947,31 @@ function _reverse_eval(
                 # and matrix children here so the generic
                 # diagonal-partial path below doesn't trip its
                 # `_size(k) == _size(ix)` assertion.
-                if (op == :+ || op == :-) &&
-                   any(
-                       c -> f.sizes.ndims[children_arr[c]] == 0,
-                       children_indices,
-                   ) &&
-                   f.sizes.ndims[k] != 0
-                    Tr = eltype(f.reverse_storage)
-                    rev_parent = _view_linear(f.reverse_storage, f.sizes, k)
-                    for c_idx in children_indices
-                        ix = children_arr[c_idx]
-                        # `:-` flips the sign for the second operand, mirroring
-                        # the partial we wrote in the forward pass.
-                        partial_sign =
-                            (op == :- && c_idx != first(children_indices)) ?
-                            -one(Tr) : one(Tr)
-                        if f.sizes.ndims[ix] == 0
-                            _setscalar!(
-                                f.reverse_storage,
-                                partial_sign * sum(rev_parent),
-                                f.sizes,
-                                ix,
-                            )
-                        else
-                            rev_child =
-                                _view_linear(f.reverse_storage, f.sizes, ix)
-                            rev_child .= partial_sign .* rev_parent
-                        end
+                if op == :+ || op == :-
+                    @assert length(children_indices) == 2
+                    child1 = first(children_indices)
+                    _reshape_call(
+                        f.reverse_storage,
+                        f.sizes,
+                        (children_arr[child1], k),
+                        sum!,
+                    )
+                    rhs = children_arr[child1+1]
+                    if op == :+
+                        _reshape_call(
+                            f.reverse_storage,
+                            f.sizes,
+                            (rhs, k),
+                            sum!,
+                        )
+                    elseif op == :-
+                        _reshape_call(
+                            f.reverse_storage,
+                            f.sizes,
+                            (rhs, k),
+                            sum!,
+                            -,
+                        )
                     end
                     continue
                 end

--- a/src/reverse_mode.jl
+++ b/src/reverse_mode.jl
@@ -411,84 +411,15 @@ function _forward_eval(
                     -,
                 )
             elseif node.index == 3 # :*  (broadcasted)
-                # Node `k` is not scalar, so we do element-wise multiply
-                # (with scalar-broadcast support: when one operand is
-                # scalar, broadcast it across the matrix output).
-                if f.sizes.ndims[k] != 0
-                    @assert N == 2
-                    idx1 = first(children_indices)
-                    idx2 = last(children_indices)
-                    @inbounds ix1 = children_arr[idx1]
-                    @inbounds ix2 = children_arr[idx2]
-                    out = _view_linear(f.forward_storage, f.sizes, k)
-                    ndims1 = f.sizes.ndims[ix1]
-                    ndims2 = f.sizes.ndims[ix2]
-                    if ndims1 == 0 && ndims2 != 0
-                        s = _getscalar(f.forward_storage, f.sizes, ix1)
-                        v = _view_linear(f.forward_storage, f.sizes, ix2)
-                        out .= s .* v
-                        # Per-element partial w.r.t. the matrix child is
-                        # the scalar; the scalar child's reverse is handled
-                        # by the broadcasted-`:*` reverse branch below
-                        # (sum of `rev_parent .* v`).
-                        fill!(_view_linear(f.partials_storage, f.sizes, ix2), s)
-                    elseif ndims1 != 0 && ndims2 == 0
-                        v = _view_linear(f.forward_storage, f.sizes, ix1)
-                        s = _getscalar(f.forward_storage, f.sizes, ix2)
-                        out .= v .* s
-                        fill!(_view_linear(f.partials_storage, f.sizes, ix1), s)
-                    else
-                        # Both children are arrays of the same shape —
-                        # original element-wise path.
-                        v1 = zeros(_size(f.sizes, ix1)...)
-                        v2 = zeros(_size(f.sizes, ix2)...)
-                        for j in _eachindex(f.sizes, ix1)
-                            v1[j] = @j f.forward_storage[ix1]
-                            @j f.partials_storage[ix2] = v1[j]
-                        end
-                        for j in _eachindex(f.sizes, ix2)
-                            v2[j] = @j f.forward_storage[ix2]
-                            @j f.partials_storage[ix1] = v2[j]
-                        end
-                        for j in _eachindex(f.sizes, k)
-                            @j f.forward_storage[k] = v1[j] * v2[j]
-                        end
-                    end
-                    # Node `k` is scalar
-                else
-                    tmp_prod = one(T)
-                    for c_idx in children_indices
-                        @inbounds tmp_prod *=
-                            f.forward_storage[children_arr[c_idx]]
-                    end
-                    if tmp_prod == zero(T) || N <= 2
-                        # This is inefficient if there are a lot of children.
-                        # 2 is chosen as a limit because (x*y)/y does not always
-                        # equal x for floating-point numbers. This can produce
-                        # unexpected error in partials. There's still an error when
-                        # multiplying three or more terms, but users are less likely
-                        # to complain about it.
-                        for c_idx in children_indices
-                            prod_others = one(T)
-                            for c_idx2 in children_indices
-                                (c_idx == c_idx2) && continue
-                                ix = children_arr[c_idx2]
-                                prod_others *= f.forward_storage[ix]
-                            end
-                            f.partials_storage[children_arr[c_idx]] =
-                                prod_others
-                        end
-                    else
-                        # Compute all-minus-one partial derivatives by dividing from
-                        # the total product.
-                        for c_idx in children_indices
-                            ix = children_arr[c_idx]
-                            f.partials_storage[ix] =
-                                tmp_prod / f.forward_storage[ix]
-                        end
-                    end
-                    @inbounds f.forward_storage[k] = tmp_prod
-                end
+                @assert N == 2
+                child1 = first(children_indices)
+                _reshape_call(
+                    f.forward_storage,
+                    f.sizes,
+                    (k, children_arr[child1], children_arr[child1+1]),
+                    broadcast!,
+                    *,
+                )
             elseif node.index == 4 # :^ (broadcasted), array .^ scalar
                 @assert N == 2
                 idx1 = first(children_indices)
@@ -603,6 +534,35 @@ function _forward_eval(
     # for vector-valued roots (use `_storage_range(f.sizes, 1)`); the scalar
     # return is only meaningful when the root is scalar.
     return f.forward_storage[1]
+end
+
+function _reverse_broadcasted_mul(dout, dlhs, drhs, lhs, rhs)
+    # Would need `conj` once we support `Complex`
+    Base.mapreducedim!(
+        identity,
+        Base.add_sum,
+        dlhs,
+        Broadcast.instantiate(Broadcast.broadcasted(*, dout, rhs)),
+    )
+    Base.mapreducedim!(
+        identity,
+        Base.add_sum,
+        drhs,
+        Broadcast.instantiate(Broadcast.broadcasted(*, lhs, dout)),
+    )
+    return
+end
+
+function __reverse_broadcasted_mul(f, ilhs, irhs, dout, dlhs, drhs)
+    return _reshape_call(
+        f.forward_storage,
+        f.sizes,
+        (ilhs, irhs),
+        _reverse_broadcasted_mul,
+        dout,
+        dlhs,
+        drhs,
+    )
 end
 
 """
@@ -889,105 +849,15 @@ function _reverse_eval(
                     continue
                 end
                 if op == :*
-                    if f.sizes.ndims[k] != 0
-                        idx1 = first(children_indices)
-                        idx2 = last(children_indices)
-                        ix1 = children_arr[idx1]
-                        ix2 = children_arr[idx2]
-                        rev_parent = _view_linear(f.reverse_storage, f.sizes, k)
-                        ndims1 = f.sizes.ndims[ix1]
-                        ndims2 = f.sizes.ndims[ix2]
-                        if ndims1 == 0 && ndims2 != 0
-                            v2 = _view_linear(f.forward_storage, f.sizes, ix2)
-                            s1 = _getscalar(f.forward_storage, f.sizes, ix1)
-                            rev_v2 =
-                                _view_linear(f.reverse_storage, f.sizes, ix2)
-                            rev_v2 .= rev_parent .* s1
-                            _setscalar!(
-                                f.reverse_storage,
-                                LinearAlgebra.dot(rev_parent, v2),
-                                f.sizes,
-                                ix1,
-                            )
-                            continue
-                        elseif ndims1 != 0 && ndims2 == 0
-                            v1 = _view_linear(f.forward_storage, f.sizes, ix1)
-                            s2 = _getscalar(f.forward_storage, f.sizes, ix2)
-                            rev_v1 =
-                                _view_linear(f.reverse_storage, f.sizes, ix1)
-                            rev_v1 .= rev_parent .* s2
-                            _setscalar!(
-                                f.reverse_storage,
-                                LinearAlgebra.dot(rev_parent, v1),
-                                f.sizes,
-                                ix2,
-                            )
-                            continue
-                        end
-                        # Both children are arrays of the same shape —
-                        # original element-wise path.
-                        v1 = zeros(_size(f.sizes, ix1)...)
-                        v2 = zeros(_size(f.sizes, ix2)...)
-                        for j in _eachindex(f.sizes, ix1)
-                            v1[j] = @j f.forward_storage[ix1]
-                        end
-                        for j in _eachindex(f.sizes, ix2)
-                            v2[j] = @j f.forward_storage[ix2]
-                        end
-                        rev_parent = zeros(_size(f.sizes, k)...)
-                        for j in _eachindex(f.sizes, k)
-                            rev_parent[j] = @j f.reverse_storage[k]
-                        end
-                        rev_v1 = zeros(_size(f.sizes, ix1)...)
-                        rev_v2 = zeros(_size(f.sizes, ix2)...)
-                        for j in _eachindex(f.sizes, ix1)
-                            rev_v1[j] = rev_parent[j] * v2[j]
-                            @j f.reverse_storage[ix1] = rev_v1[j]
-                        end
-                        for j in _eachindex(f.sizes, ix2)
-                            rev_v2[j] = rev_parent[j] * v1[j]
-                            @j f.reverse_storage[ix2] = rev_v2[j]
-                        end
-                        continue
-                    end
-                elseif op == :^
-                    # Broadcasted array .^ scalar: vectorize the per-element
-                    # base reverse (with 0*Inf guard preserved) and reduce
-                    # the exponent contribution as a single `sum` over GPU
-                    # arrays.
-                    @assert length(children_indices) == 2
-                    idx1 = first(children_indices)
-                    idx2 = last(children_indices)
-                    @inbounds ix1 = children_arr[idx1]
-                    @inbounds ix2 = children_arr[idx2]
-                    rev_parent = _view_linear(f.reverse_storage, f.sizes, k)
-                    rev_v1 = _view_linear(f.reverse_storage, f.sizes, ix1)
-                    partial = _view_linear(f.partials_storage, f.sizes, ix1)
-                    rev_v1 .= ifelse.(
-                        (rev_parent .== 0) .& .!isfinite.(partial),
-                        rev_parent,
-                        rev_parent .* partial,
+                    _reshape_call(
+                        f.reverse_storage,
+                        f.sizes,
+                        (k, lhs, rhs),
+                        __reverse_broadcasted_mul,
+                        f,
+                        lhs,
+                        rhs,
                     )
-                    base_view = _view_linear(f.forward_storage, f.sizes, ix1)
-                    out_view = _view_linear(f.forward_storage, f.sizes, k)
-                    # `mapreduce(f, +, base_view, rev_parent, out_view)`
-                    # would express this directly, but multi-iterable
-                    # `mapreduce` materializes an intermediate today
-                    # (JuliaLang/julia#53417). Wrap the inputs in `zip` so
-                    # the single-iterable specialization fires and the
-                    # reduction stays allocation-free. Once
-                    # https://github.com/JuliaLang/julia/pull/55301 lands
-                    # we can drop the `zip` and use the multi-arg form.
-                    T = eltype(rev_parent)
-                    rev_exp_total = mapreduce(
-                        +,
-                        zip(base_view, rev_parent, out_view);
-                        init = zero(T),
-                    ) do (b, rp, o)
-                        return b > 0 ? rp * o * log(b) : zero(T)
-                    end
-                    pos2 = _scalar_pos(f.sizes, ix2)
-                    view(f.reverse_storage, pos2:pos2) .= rev_exp_total
                     continue
                 end
             end

--- a/src/reverse_mode.jl
+++ b/src/reverse_mode.jl
@@ -95,162 +95,44 @@ function _forward_broadcasted(
     return out .= lhs .+ rhs
 end
 
-function _forward_broadcasted_1(
-    op::Union{typeof(+),typeof(-),typeof(*)},
-    f::_SubexpressionStorage,
-    d::NLPEvaluator,
-    x::AbstractVector,
-    out,
-    lhs,
-    rhs::Int,
-)
-    ndims = f.sizes.ndims[rhs]
-    if ndims == 0
-        _forward_broadcasted(
-            op,
-            f,
-            d,
-            x,
-            out,
-            lhs,
-            _getscalar(f.forward_storage, f.sizes, rhs),
-        )
-    elseif ndims == 1
-        _forward_broadcasted(
-            op,
-            f,
-            d,
-            x,
-            out,
-            lhs,
-            _view_linear(f.forward_storage, f.sizes, rhs),
-        )
-    elseif ndims == 2
-        _forward_broadcasted(
-            op,
-            f,
-            d,
-            x,
-            out,
-            lhs,
-            _view_matrix(f.forward_storage, f.sizes, rhs),
-        )
-    else
-        _forward_broadcasted(
-            op,
-            f,
-            d,
-            x,
-            out,
-            lhs,
-            _view_array(f.forward_storage, f.sizes, rhs),
-        )
-    end
+function _reshape_forward_broadcasted(::Tuple{}, args...)
+    return _forward_broadcasted(args...)
 end
 
-function _forward_broadcasted_2(
-    op::Union{typeof(+),typeof(-),typeof(*)},
-    f::_SubexpressionStorage,
-    d::NLPEvaluator,
-    x::AbstractVector,
-    out,
-    lhs::Int,
-    rhs::Int,
-)
-    ndims = f.sizes.ndims[lhs]
+function _reshape_forward_broadcasted(nodes::Tuple, op, f, args...)
+    node = first(nodes)
+    ndims = f.sizes.ndims[node]
     if ndims == 0
-        _forward_broadcasted_1(
+        _reshape_forward_broadcasted(
+            Base.tail(nodes),
             op,
             f,
-            d,
-            x,
-            out,
-            _getscalar(f.forward_storage, f.sizes, lhs),
-            rhs,
+            args...,
+            _getscalar(f.forward_storage, f.sizes, node),
         )
     elseif ndims == 1
-        _forward_broadcasted_1(
+        _reshape_forward_broadcasted(
+            Base.tail(nodes),
             op,
             f,
-            d,
-            x,
-            out,
-            _view_linear(f.forward_storage, f.sizes, lhs),
-            rhs,
+            args...,
+            _view_linear(f.forward_storage, f.sizes, node),
         )
     elseif ndims == 2
-        _forward_broadcasted_1(
+        _reshape_forward_broadcasted(
+            Base.tail(nodes),
             op,
             f,
-            d,
-            x,
-            out,
-            _view_matrix(f.forward_storage, f.sizes, lhs),
-            rhs,
+            args...,
+            _view_matrix(f.forward_storage, f.sizes, node),
         )
     else
-        _forward_broadcasted_1(
+        _reshape_forward_broadcasted(
+            Base.tail(nodes),
             op,
             f,
-            d,
-            x,
-            out,
-            _view_array(f.forward_storage, f.sizes, lhs),
-            rhs,
-        )
-    end
-end
-
-# _3 means the last 3 arguments are node indices and should be replaced by the arrays
-function _forward_broadcasted_3(
-    op::Union{typeof(+),typeof(-),typeof(*)},
-    f::_SubexpressionStorage,
-    d::NLPEvaluator,
-    x::AbstractVector,
-    k::Int,
-    lhs::Int,
-    rhs::Int,
-)
-    ndims = f.sizes.ndims[k]
-    if ndims == 0
-        _forward_broadcasted_2(
-            op,
-            f,
-            d,
-            x,
-            _getscalar(f.forward_storage, f.sizes, k),
-            lhs,
-            rhs,
-        )
-    elseif ndims == 1
-        _forward_broadcasted_2(
-            op,
-            f,
-            d,
-            x,
-            _view_linear(f.forward_storage, f.sizes, k),
-            lhs,
-            rhs,
-        )
-    elseif ndims == 2
-        _forward_broadcasted_2(
-            op,
-            f,
-            d,
-            x,
-            _view_matrix(f.forward_storage, f.sizes, k),
-            lhs,
-            rhs,
-        )
-    else
-        _forward_broadcasted_2(
-            op,
-            f,
-            d,
-            x,
-            _view_array(f.forward_storage, f.sizes, k),
-            lhs,
-            rhs,
+            args...,
+            _view_array(f.forward_storage, f.sizes, node),
         )
     end
 end
@@ -565,14 +447,12 @@ function _forward_eval(
             if node.index == 1 # :+  (broadcasted)
                 @assert N == 2
                 child1 = first(children_indices)
-                _forward_broadcasted_3(
+                _reshape_forward_broadcasted(
+                    (k, children_arr[child1], children_arr[child1+1]),
                     +,
                     f,
                     d,
                     x,
-                    k,
-                    children_arr[child1],
-                    children_arr[child1+1],
                 )
                 fill!(
                     _view_linear(

--- a/src/reverse_mode.jl
+++ b/src/reverse_mode.jl
@@ -83,61 +83,6 @@ function _reverse_mode(d::NLPEvaluator, x)
     return
 end
 
-function _forward_broadcasted(
-    op::Union{typeof(+),typeof(-)},
-    f::_SubexpressionStorage,
-    d::NLPEvaluator,
-    x::AbstractVector,
-    out,
-    lhs,
-    rhs,
-)
-    broadcast!(op, out, lhs, rhs)
-    return
-end
-
-function _reshape_call(_, _::Sizes, ::Tuple{}, op, args...)
-    return op(args...)
-end
-
-function _reshape_call(storage, sizes::Sizes, nodes::Tuple, args...)
-    node = first(nodes)
-    ndims = sizes.ndims[node]
-    if ndims == 0
-        _reshape_call(
-            storage,
-            sizes,
-            Base.tail(nodes),
-            args...,
-            _view_scalar(storage, sizes, node),
-        )
-    elseif ndims == 1
-        _reshape_call(
-            storage,
-            sizes,
-            Base.tail(nodes),
-            args...,
-            _view_linear(storage, sizes, node),
-        )
-    elseif ndims == 2
-        _reshape_call(
-            storage,
-            sizes,
-            Base.tail(nodes),
-            args...,
-            _view_matrix(storage, sizes, node),
-        )
-    else
-        _reshape_call(
-            storage,
-            sizes,
-            Base.tail(nodes),
-            args...,
-            _view_array(storage, sizes, node),
-        )
-    end
-end
-
 """
     _forward_eval(
         f::_SubexpressionStorage,
@@ -464,22 +409,6 @@ function _forward_eval(
                     (k, children_arr[child1], children_arr[child1+1]),
                     broadcast!,
                     -,
-                )
-                fill!(
-                    _view_linear(
-                        f.partials_storage,
-                        f.sizes,
-                        children_arr[child1],
-                    ),
-                    one(T),
-                )
-                fill!(
-                    _view_linear(
-                        f.partials_storage,
-                        f.sizes,
-                        children_arr[child1+1],
-                    ),
-                    -one(T),
                 )
             elseif node.index == 3 # :*  (broadcasted)
                 # Node `k` is not scalar, so we do element-wise multiply

--- a/src/reverse_mode.jl
+++ b/src/reverse_mode.jl
@@ -83,6 +83,178 @@ function _reverse_mode(d::NLPEvaluator, x)
     return
 end
 
+function _forward_broadcasted(
+    ::typeof(+),
+    f::_SubexpressionStorage,
+    d::NLPEvaluator,
+    x::AbstractVector,
+    out,
+    lhs,
+    rhs,
+)
+    return out .= lhs .+ rhs
+end
+
+function _forward_broadcasted_1(
+    op::Union{typeof(+),typeof(-),typeof(*)},
+    f::_SubexpressionStorage,
+    d::NLPEvaluator,
+    x::AbstractVector,
+    out,
+    lhs,
+    rhs::Int,
+)
+    ndims = f.sizes.ndims[rhs]
+    if ndims == 0
+        _forward_broadcasted(
+            op,
+            f,
+            d,
+            x,
+            out,
+            lhs,
+            _getscalar(f.forward_storage, f.sizes, rhs),
+        )
+    elseif ndims == 1
+        _forward_broadcasted(
+            op,
+            f,
+            d,
+            x,
+            out,
+            lhs,
+            _view_linear(f.forward_storage, f.sizes, rhs),
+        )
+    elseif ndims == 2
+        _forward_broadcasted(
+            op,
+            f,
+            d,
+            x,
+            out,
+            lhs,
+            _view_matrix(f.forward_storage, f.sizes, rhs),
+        )
+    else
+        _forward_broadcasted(
+            op,
+            f,
+            d,
+            x,
+            out,
+            lhs,
+            _view_array(f.forward_storage, f.sizes, rhs),
+        )
+    end
+end
+
+function _forward_broadcasted_2(
+    op::Union{typeof(+),typeof(-),typeof(*)},
+    f::_SubexpressionStorage,
+    d::NLPEvaluator,
+    x::AbstractVector,
+    out,
+    lhs::Int,
+    rhs::Int,
+)
+    ndims = f.sizes.ndims[lhs]
+    if ndims == 0
+        _forward_broadcasted_1(
+            op,
+            f,
+            d,
+            x,
+            out,
+            _getscalar(f.forward_storage, f.sizes, lhs),
+            rhs,
+        )
+    elseif ndims == 1
+        _forward_broadcasted_1(
+            op,
+            f,
+            d,
+            x,
+            out,
+            _view_linear(f.forward_storage, f.sizes, lhs),
+            rhs,
+        )
+    elseif ndims == 2
+        _forward_broadcasted_1(
+            op,
+            f,
+            d,
+            x,
+            out,
+            _view_matrix(f.forward_storage, f.sizes, lhs),
+            rhs,
+        )
+    else
+        _forward_broadcasted_1(
+            op,
+            f,
+            d,
+            x,
+            out,
+            _view_array(f.forward_storage, f.sizes, lhs),
+            rhs,
+        )
+    end
+end
+
+# _3 means the last 3 arguments are node indices and should be replaced by the arrays
+function _forward_broadcasted_3(
+    op::Union{typeof(+),typeof(-),typeof(*)},
+    f::_SubexpressionStorage,
+    d::NLPEvaluator,
+    x::AbstractVector,
+    k::Int,
+    lhs::Int,
+    rhs::Int,
+)
+    ndims = f.sizes.ndims[k]
+    if ndims == 0
+        _forward_broadcasted_2(
+            op,
+            f,
+            d,
+            x,
+            _getscalar(f.forward_storage, f.sizes, k),
+            lhs,
+            rhs,
+        )
+    elseif ndims == 1
+        _forward_broadcasted_2(
+            op,
+            f,
+            d,
+            x,
+            _view_linear(f.forward_storage, f.sizes, k),
+            lhs,
+            rhs,
+        )
+    elseif ndims == 2
+        _forward_broadcasted_2(
+            op,
+            f,
+            d,
+            x,
+            _view_matrix(f.forward_storage, f.sizes, k),
+            lhs,
+            rhs,
+        )
+    else
+        _forward_broadcasted_2(
+            op,
+            f,
+            d,
+            x,
+            _view_array(f.forward_storage, f.sizes, k),
+            lhs,
+            rhs,
+        )
+    end
+end
+
 """
     _forward_eval(
         f::_SubexpressionStorage,
@@ -391,25 +563,33 @@ function _forward_eval(
             children_indices = SparseArrays.nzrange(f.adj, k)
             N = length(children_indices)
             if node.index == 1 # :+  (broadcasted)
-                # Broadcast-aware sum: scalar children contribute their
-                # single value to every output slot.
-                out = _view_linear(f.forward_storage, f.sizes, k)
-                fill!(out, zero(T))
-                for c_idx in children_indices
-                    ix = children_arr[c_idx]
-                    if f.sizes.ndims[ix] == 0
-                        s = _getscalar(f.forward_storage, f.sizes, ix)
-                        out .+= s
-                        _setscalar!(f.partials_storage, one(T), f.sizes, ix)
-                    else
-                        v = _view_linear(f.forward_storage, f.sizes, ix)
-                        out .+= v
-                        fill!(
-                            _view_linear(f.partials_storage, f.sizes, ix),
-                            one(T),
-                        )
-                    end
-                end
+                @assert N == 2
+                child1 = first(children_indices)
+                _forward_broadcasted_3(
+                    +,
+                    f,
+                    d,
+                    x,
+                    k,
+                    children_arr[child1],
+                    children_arr[child1+1],
+                )
+                fill!(
+                    _view_linear(
+                        f.partials_storage,
+                        f.sizes,
+                        children_arr[child1],
+                    ),
+                    one(T),
+                )
+                fill!(
+                    _view_linear(
+                        f.partials_storage,
+                        f.sizes,
+                        children_arr[child1+1],
+                    ),
+                    one(T),
+                )
             elseif node.index == 2 # :-  (broadcasted)
                 @assert N == 2
                 child1 = first(children_indices)

--- a/src/reverse_mode.jl
+++ b/src/reverse_mode.jl
@@ -537,6 +537,11 @@ function _forward_eval(
 end
 
 function _reverse_broadcasted_mul(dout, dlhs, drhs, lhs, rhs)
+    # `reverse_storage` is zeroed out at construction but if
+    # at the second call of `eval_objective_gradient`, it is not
+    # zero so we can't assume that it is zero
+    end
+    fill!(dlhs, zero(eltype(dlhs)))
     # Would need `conj` once we support `Complex`
     Base.mapreducedim!(
         identity,
@@ -544,6 +549,7 @@ function _reverse_broadcasted_mul(dout, dlhs, drhs, lhs, rhs)
         dlhs,
         Broadcast.instantiate(Broadcast.broadcasted(*, dout, rhs)),
     )
+    fill!(drhs, zero(eltype(drhs)))
     Base.mapreducedim!(
         identity,
         Base.add_sum,

--- a/src/reverse_mode.jl
+++ b/src/reverse_mode.jl
@@ -96,42 +96,38 @@ function _forward_broadcasted(
     return
 end
 
-function _reshape_forward_broadcasted(::Tuple{}, args...)
-    return _forward_broadcasted(args...)
+function _reshape_call(::_SubexpressionStorage, ::Tuple{}, op, args...)
+    return op(args...)
 end
 
-function _reshape_forward_broadcasted(nodes::Tuple, op, f, args...)
+function _reshape_call(f, nodes::Tuple, args...)
     node = first(nodes)
     ndims = f.sizes.ndims[node]
     if ndims == 0
-        _reshape_forward_broadcasted(
-            Base.tail(nodes),
-            op,
+        _reshape_call(
             f,
+            Base.tail(nodes),
             args...,
             _getscalar(f.forward_storage, f.sizes, node),
         )
     elseif ndims == 1
-        _reshape_forward_broadcasted(
-            Base.tail(nodes),
-            op,
+        _reshape_call(
             f,
+            Base.tail(nodes),
             args...,
             _view_linear(f.forward_storage, f.sizes, node),
         )
     elseif ndims == 2
-        _reshape_forward_broadcasted(
-            Base.tail(nodes),
-            op,
+        _reshape_call(
             f,
+            Base.tail(nodes),
             args...,
             _view_matrix(f.forward_storage, f.sizes, node),
         )
     else
-        _reshape_forward_broadcasted(
-            Base.tail(nodes),
-            op,
+        _reshape_call(
             f,
+            Base.tail(nodes),
             args...,
             _view_array(f.forward_storage, f.sizes, node),
         )
@@ -448,12 +444,11 @@ function _forward_eval(
             if node.index == 1 # :+  (broadcasted)
                 @assert N == 2
                 child1 = first(children_indices)
-                _reshape_forward_broadcasted(
-                    (k, children_arr[child1], children_arr[child1+1]),
-                    +,
+                _reshape_call(
                     f,
-                    d,
-                    x,
+                    (k, children_arr[child1], children_arr[child1+1]),
+                    broadcast!,
+                    +,
                 )
                 fill!(
                     _view_linear(
@@ -474,12 +469,11 @@ function _forward_eval(
             elseif node.index == 2 # :-  (broadcasted)
                 @assert N == 2
                 child1 = first(children_indices)
-                _reshape_forward_broadcasted(
-                    (k, children_arr[child1], children_arr[child1+1]),
-                    -,
+                _reshape_call(
                     f,
-                    d,
-                    x,
+                    (k, children_arr[child1], children_arr[child1+1]),
+                    broadcast!,
+                    -,
                 )
                 fill!(
                     _view_linear(

--- a/src/reverse_mode.jl
+++ b/src/reverse_mode.jl
@@ -540,7 +540,6 @@ function _reverse_broadcasted_mul(dout, dlhs, drhs, lhs, rhs)
     # `reverse_storage` is zeroed out at construction but if
     # at the second call of `eval_objective_gradient`, it is not
     # zero so we can't assume that it is zero
-    end
     fill!(dlhs, zero(eltype(dlhs)))
     # Would need `conj` once we support `Complex`
     Base.mapreducedim!(

--- a/src/reverse_mode.jl
+++ b/src/reverse_mode.jl
@@ -398,7 +398,7 @@ function _forward_eval(
                     f.sizes,
                     (k, children_arr[child1], children_arr[child1+1]),
                     broadcast!,
-                    +,
+                    (+,),
                 )
             elseif node.index == 2 # :-  (broadcasted)
                 @assert N == 2
@@ -408,7 +408,7 @@ function _forward_eval(
                     f.sizes,
                     (k, children_arr[child1], children_arr[child1+1]),
                     broadcast!,
-                    -,
+                    (-,),
                 )
             elseif node.index == 3 # :*  (broadcasted)
                 @assert N == 2
@@ -418,7 +418,7 @@ function _forward_eval(
                     f.sizes,
                     (k, children_arr[child1], children_arr[child1+1]),
                     broadcast!,
-                    *,
+                    (*,),
                 )
             elseif node.index == 4 # :^ (broadcasted), array .^ scalar
                 @assert N == 2
@@ -564,9 +564,7 @@ function __reverse_broadcasted_mul(f, ilhs, irhs, dout, dlhs, drhs)
         f.sizes,
         (ilhs, irhs),
         _reverse_broadcasted_mul,
-        dout,
-        dlhs,
-        drhs,
+        (dout, dlhs, drhs),
     )
 end
 
@@ -836,9 +834,7 @@ function _reverse_eval(
                             f.sizes,
                             (k, lhs, rhs),
                             __reverse_broadcasted_mul,
-                            f,
-                            lhs,
-                            rhs,
+                            (f, lhs, rhs),
                         )
                     else
                         _reshape_call(
@@ -846,6 +842,7 @@ function _reverse_eval(
                             f.sizes,
                             (children_arr[child1], k),
                             sum!,
+                            tuple(),
                         )
                         rhs = children_arr[child1+1]
                         if op == :+
@@ -854,6 +851,7 @@ function _reverse_eval(
                                 f.sizes,
                                 (rhs, k),
                                 sum!,
+                                tuple(),
                             )
                         elseif op == :-
                             _reshape_call(
@@ -861,7 +859,7 @@ function _reverse_eval(
                                 f.sizes,
                                 (rhs, k),
                                 sum!,
-                                -,
+                                (-,),
                             )
                         end
                     end

--- a/src/reverse_mode.jl
+++ b/src/reverse_mode.jl
@@ -436,10 +436,8 @@ function _forward_eval(
                 partials = _view_linear(f.partials_storage, f.sizes, ix1)
                 if exponent == 2
                     out .= inp .* inp
-                    partials .= 2 .* inp
                 elseif exponent == 1
                     out .= inp
-                    fill!(partials, one(T))
                 else
                     out .= pow.(inp, exponent)
                     partials .= exponent .* pow.(inp, exponent - 1)
@@ -823,7 +821,7 @@ function _reverse_eval(
                 # and matrix children here so the generic
                 # diagonal-partial path below doesn't trip its
                 # `_size(k) == _size(ix)` assertion.
-                if op == :+ || op == :- || op == :*
+                if op == :+ || op == :- || op == :* || op == :^
                     @assert length(children_indices) == 2
                     child1 = first(children_indices)
                     lhs = children_arr[child1]
@@ -836,6 +834,30 @@ function _reverse_eval(
                             __reverse_broadcasted_mul,
                             (f, lhs, rhs),
                         )
+                    elseif op == :^
+                        # We start with just .^2 to simplify
+                        @assert f.sizes.ndims[rhs] == 0 "Broadcasted ^ requires scalar exponent"
+                        exp = _getscalar(f.forward_storage, f.sizes, rhs)
+                        # To simplify, so we don't need to compute its derivative
+                        @assert f.nodes[rhs].type == NODE_VALUE
+                        rev_parent = _view_linear(f.reverse_storage, f.sizes, k)
+                        rev_child =
+                            _view_linear(f.reverse_storage, f.sizes, lhs)
+                        if exp == 2
+                            child =
+                                _view_linear(f.forward_storage, f.sizes, lhs)
+                            rev_child .= 2 .* child .* rev_parent
+                        elseif exp == 1
+                            rev_child .= rev_parent
+                        else
+                            partial =
+                                _view_linear(f.partials_storage, f.sizes, lhs)
+                            rev_child .= ifelse.(
+                                (rev_parent .== 0) .& .!isfinite.(partial),
+                                rev_parent,
+                                rev_parent .* partial,
+                            )
+                        end
                     else
                         _reshape_call(
                             f.reverse_storage,

--- a/src/sizes.jl
+++ b/src/sizes.jl
@@ -49,8 +49,7 @@ function _setscalar!(x, value, sizes::Sizes, k::Int)
     # Use a 1-element view + broadcast so this works on GPU storage as well as
     # `Vector{Float64}`. Direct `x[idx] = value` is a scalar setindex which
     # GPUArrays disallows by default.
-    pos = _scalar_pos(sizes, k)
-    view(x, reshape(pos:pos, ())) .= value
+    _view_scalar(x, sizes, k) .= value
     return value
 end
 
@@ -80,6 +79,11 @@ implementation just calls `getindex`; this is a hook for storage backends
 1-element transfer instead.
 """
 _scalar_load(storage::AbstractVector, idx::Int) = @inbounds storage[idx]
+
+function _view_scalar(storage::AbstractVector, sizes::Sizes, k::Int)
+    pos = _scalar_pos(sizes, k)
+    return view(storage, reshape(pos:pos, ()))
+end
 
 """
     _view_linear(storage, sizes, k) -> SubArray

--- a/src/sizes.jl
+++ b/src/sizes.jl
@@ -123,46 +123,130 @@ function _view_matrix(storage::AbstractVector, sizes::Sizes, k::Int)
     return reshape(v, (m, n))
 end
 
-function _reshape_call(_, _::Sizes, ::Tuple{}, op, args...)
-    return op(args...)
-end
+# Force specialization, (args..., x) is calling Core._apply_iterate
+@inline _push(::Tuple{}, x) = (x,)
+@inline _push(t::Tuple{Any}, x) = (t[1], x)
+@inline _push(t::Tuple{Any,Any}, x) = (t[1], t[2], x)
+@inline _push(t::Tuple{Any,Any,Any}, x) = (t[1], t[2], t[3], x)
+@inline _push(t::Tuple{Any,Any,Any,Any}, x) = (t[1], t[2], t[3], t[4], x)
+@inline _push(t::Tuple{Any,Any,Any,Any,Any}, x) =
+    (t[1], t[2], t[3], t[4], t[5], x)
+@inline _push(t::Tuple{Any,Any,Any,Any,Any,Any}, x) =
+    (t[1], t[2], t[3], t[4], t[5], t[6], x)
+@inline _push(t::Tuple{Any,Any,Any,Any,Any,Any,Any}, x) =
+    (t[1], t[2], t[3], t[4], t[5], t[6], t[7], x)
 
-function _reshape_call(storage, sizes::Sizes, nodes::Tuple, args...)
-    node = first(nodes)
-    ndims = sizes.ndims[node]
-    if ndims == 0
-        _reshape_call(
-            storage,
-            sizes,
-            Base.tail(nodes),
-            args...,
-            _view_scalar(storage, sizes, node),
-        )
-    elseif ndims == 1
-        _reshape_call(
-            storage,
-            sizes,
-            Base.tail(nodes),
-            args...,
-            _view_linear(storage, sizes, node),
-        )
-    elseif ndims == 2
-        _reshape_call(
-            storage,
-            sizes,
-            Base.tail(nodes),
-            args...,
-            _view_matrix(storage, sizes, node),
-        )
-    else
-        _reshape_call(
-            storage,
-            sizes,
-            Base.tail(nodes),
-            args...,
-            _view_array(storage, sizes, node), # TODO
+# The following is almost allocation-free but I couldn't figure out why it's not
+# Claude generated below an implementation with a generated function but it if we could
+# make the simpler version, without @generated, work, it would be simpler.
+
+#@inline function _reshape_call(
+#    _,
+#    _::Sizes,
+#    ::Tuple{},
+#    op::F,
+#    args::Tuple,
+#) where {F<:Function}
+#    op(args...)
+#    return
+#end
+
+#@inline function _reshape_call(
+#    storage,
+#    sizes::Sizes,
+#    nodes::NTuple{N,Int},
+#    op::F,
+#    args::Tuple,
+#) where {N,F<:Function}
+#    node = first(nodes)
+#    ndims = sizes.ndims[node]
+#    if ndims == 0
+#        _reshape_call(
+#            storage,
+#            sizes,
+#            Base.tail(nodes),
+#            op,
+#            _push(args, _view_scalar(storage, sizes, node)),
+#        )
+#    elseif ndims == 1
+#        _reshape_call(
+#            storage,
+#            sizes,
+#            Base.tail(nodes),
+#            op,
+#            _push(args, _view_linear(storage, sizes, node)),
+#        )
+#    elseif ndims == 2
+#        _reshape_call(
+#            storage,
+#            sizes,
+#            Base.tail(nodes),
+#            op,
+#            _push(args, _view_matrix(storage, sizes, node)),
+#        )
+#    else
+#        @assert false
+#        #        _reshape_call(
+#        #            storage,
+#        #            sizes,
+#        #            Base.tail(nodes),
+#        #            args...,
+#        #            _view_array(storage, sizes, node), # TODO
+#        #        )
+#    end
+#    return
+#end
+
+@generated function _reshape_call(
+    storage,
+    sizes::Sizes,
+    nodes::NTuple{N,Int},
+    op::F,
+    args::Tuple = (),
+) where {N,F}
+    # At each level, branch on ndims and CONTINUE recursively inside the chosen
+    # branch with the concrete view type. No phi-merge into Any, no Union args.
+    # The price: 4^N specialized paths, but each is fully type-stable.
+    function emit_level(i, args_sym)
+        if i > N
+            return Expr(:call, :op, Expr(:..., args_sym))
+        end
+        node_i = Symbol(:node_, i)
+        nd_i = Symbol(:nd_, i)
+        # In each branch, push the concrete view onto args and recurse to next level.
+        function with_view(view_call)
+            v = Symbol(:view_, i)
+            a = Symbol(:args_, i)
+            return Expr(
+                :block,
+                :($v = $view_call),
+                :($a = _push($args_sym, $v)),
+                emit_level(i + 1, a),
+            )
+        end
+        return Expr(
+            :block,
+            :($node_i = nodes[$i]),
+            :($nd_i = sizes.ndims[$node_i]),
+            Expr(
+                :if,
+                :($nd_i == 0),
+                with_view(:(_view_scalar(storage, sizes, $node_i))),
+                Expr(
+                    :elseif,
+                    :($nd_i == 1),
+                    with_view(:(_view_linear(storage, sizes, $node_i))),
+                    Expr(
+                        :elseif,
+                        :($nd_i == 2),
+                        with_view(:(_view_matrix(storage, sizes, $node_i))),
+                        with_view(:(_view_array(storage, sizes, $node_i))),
+                    ),
+                ),
+            ),
         )
     end
+    return Expr(:block, emit_level(1, :args), :(return nothing))
 end
 
 """

--- a/src/sizes.jl
+++ b/src/sizes.jl
@@ -123,6 +123,48 @@ function _view_matrix(storage::AbstractVector, sizes::Sizes, k::Int)
     return reshape(v, (m, n))
 end
 
+function _reshape_call(_, _::Sizes, ::Tuple{}, op, args...)
+    return op(args...)
+end
+
+function _reshape_call(storage, sizes::Sizes, nodes::Tuple, args...)
+    node = first(nodes)
+    ndims = sizes.ndims[node]
+    if ndims == 0
+        _reshape_call(
+            storage,
+            sizes,
+            Base.tail(nodes),
+            args...,
+            _view_scalar(storage, sizes, node),
+        )
+    elseif ndims == 1
+        _reshape_call(
+            storage,
+            sizes,
+            Base.tail(nodes),
+            args...,
+            _view_linear(storage, sizes, node),
+        )
+    elseif ndims == 2
+        _reshape_call(
+            storage,
+            sizes,
+            Base.tail(nodes),
+            args...,
+            _view_matrix(storage, sizes, node),
+        )
+    else
+        _reshape_call(
+            storage,
+            sizes,
+            Base.tail(nodes),
+            args...,
+            _view_array(storage, sizes, node), # TODO
+        )
+    end
+end
+
 """
     @s(storage[node]) -> _getscalar(storage, f.sizes, node)
     @s(storage[node] = value) -> _setscalar!(storage, value, f.sizes, node)

--- a/test/JuMP.jl
+++ b/test/JuMP.jl
@@ -490,6 +490,79 @@ function test_broadcast_scalar_matrix_size_inference()
     return
 end
 
+# Verify the forward value and the analytic gradient for every
+# `Number op MatrixVar` / `MatrixVar op Number` broadcast pattern that
+# JuMP's `Base.broadcasted` produces. The size inference test above pins
+# the shape inference; this test pins the eval (`out .= s op v`) and
+# reverse paths (`rev_s = ±sum(rev_parent)` or `dot(rev_parent, v)`).
+# Loss is `sum((c op W) .^ 2)` so the analytic gradient has a closed form.
+function test_broadcast_scalar_matrix_gradient()
+    c = 2.5
+    rows, cols = 2, 3
+    x = Float64.(collect(1:rows*cols))
+    W_val = reshape(x, rows, cols)
+    @testset "$(name)" for (name, build_loss, ref_val, ref_grad) in [
+        (
+            "c .+ W",
+            W -> sum((c .+ W) .^ 2),
+            sum((c .+ W_val) .^ 2),
+            2 .* (c .+ W_val),
+        ),
+        (
+            "W .+ c",
+            W -> sum((W .+ c) .^ 2),
+            sum((W_val .+ c) .^ 2),
+            2 .* (W_val .+ c),
+        ),
+        (
+            "c .- W",
+            W -> sum((c .- W) .^ 2),
+            sum((c .- W_val) .^ 2),
+            -2 .* (c .- W_val),
+        ),
+        (
+            "W .- c",
+            W -> sum((W .- c) .^ 2),
+            sum((W_val .- c) .^ 2),
+            2 .* (W_val .- c),
+        ),
+        (
+            "c .* W",
+            W -> sum((c .* W) .^ 2),
+            sum((c .* W_val) .^ 2),
+            2 * c^2 .* W_val,
+        ),
+        (
+            "W .* c",
+            W -> sum((W .* c) .^ 2),
+            sum((W_val .* c) .^ 2),
+            2 * c^2 .* W_val,
+        ),
+    ]
+        model = Model()
+        @variable(
+            model,
+            W[1:rows, 1:cols],
+            container = ArrayDiff.ArrayOfVariables,
+        )
+        loss = build_loss(W)
+        mode = ArrayDiff.Mode()
+        ad = ArrayDiff.model(mode)
+        MOI.Nonlinear.set_objective(ad, JuMP.moi_function(loss))
+        evaluator = MOI.Nonlinear.Evaluator(
+            ad,
+            mode,
+            JuMP.index.(JuMP.all_variables(model)),
+        )
+        MOI.initialize(evaluator, [:Grad])
+        @test MOI.eval_objective(evaluator, x) ≈ ref_val
+        g = zero(x)
+        MOI.eval_objective_gradient(evaluator, g, x)
+        @test g ≈ vec(ref_grad)
+    end
+    return
+end
+
 end  # module
 
 TestJuMP.runtests()

--- a/test/JuMP.jl
+++ b/test/JuMP.jl
@@ -468,7 +468,7 @@ function test_broadcast_scalar_matrix_gradient()
     rows, cols = 2, 3
     model = Model()
     @variable(model, W[1:rows, 1:cols], container = ArrayDiff.ArrayOfVariables)
-    x = Float64.(collect(1:rows*cols))
+    x = Float64.(collect(1:(rows*cols)))
     W_val = reshape(x, rows, cols)
     @testset "$(name)" for (name, expr, ref_mat, dexpr_dW) in [
         ("scalar .+ M", c .+ W, c .+ W_val, fill(1.0, rows, cols)),

--- a/test/JuMP.jl
+++ b/test/JuMP.jl
@@ -457,108 +457,40 @@ function test_broadcast_nonsquare_matrix()
     return
 end
 
-function test_broadcast_scalar_matrix_size_inference()
-    model = Model()
-    @variable(model, W[1:2, 1:3], container = ArrayDiff.ArrayOfVariables)
-    mode = ArrayDiff.Mode()
-    @testset "$(name)" for (name, expr) in [
-        ("scalar .* M", LinearAlgebra.norm(2.5 .* W)),
-        ("M .* scalar", LinearAlgebra.norm(W .* 2.5)),
-        ("scalar .+ M", LinearAlgebra.norm(2.5 .+ W)),
-        ("M .+ scalar", LinearAlgebra.norm(W .+ 2.5)),
-        ("scalar .- M", LinearAlgebra.norm(2.5 .- W)),
-        ("M .- scalar", LinearAlgebra.norm(W .- 2.5)),
-    ]
-        ad = ArrayDiff.model(mode)
-        MOI.Nonlinear.set_objective(ad, JuMP.moi_function(expr))
-        evaluator = MOI.Nonlinear.Evaluator(
-            ad,
-            mode,
-            JuMP.index.(JuMP.all_variables(model)),
-        )
-        MOI.initialize(evaluator, [:Grad])
-        sizes = evaluator.backend.objective.expr.sizes
-        # Broadcast node is at index 2; it should inherit the matrix child's
-        # (2, 3) shape, not the old `(1, 1)` stub.
-        @test sizes.ndims[2] == 2
-        broadcast_size_off = sizes.size_offset[2]
-        @test sizes.size[broadcast_size_off+1] == 2
-        @test sizes.size[broadcast_size_off+2] == 3
-        # And the scalar leaf among the children stays ndims=0.
-        @test 0 in sizes.ndims[3:4]
-    end
-    return
-end
-
-# Verify the forward value and the analytic gradient for every
-# `Number op MatrixVar` / `MatrixVar op Number` broadcast pattern that
-# JuMP's `Base.broadcasted` produces. The size inference test above pins
-# the shape inference; this test pins the eval (`out .= s op v`) and
-# reverse paths (`rev_s = ±sum(rev_parent)` or `dot(rev_parent, v)`).
-# Loss is `sum((c op W) .^ 2)` so the analytic gradient has a closed form.
+# Cover every `Number op MatrixVar` / `MatrixVar op Number` broadcast
+# pattern that JuMP's `Base.broadcasted` produces — both the size inference
+# (broadcast node inherits the matrix child's shape, not the old `(1, 1)`
+# stub) and the eval/reverse paths (`out .= s op v`, `rev_s =
+# ±sum(rev_parent)` or `dot(rev_parent, v)`). Loss is `norm(c op W)` so the
+# analytic gradient is `dexpr_dW .* (c op W) ./ norm(c op W)`.
 function test_broadcast_scalar_matrix_gradient()
     c = 2.5
     rows, cols = 2, 3
+    model = Model()
+    @variable(model, W[1:rows, 1:cols], container = ArrayDiff.ArrayOfVariables)
     x = Float64.(collect(1:rows*cols))
     W_val = reshape(x, rows, cols)
-    @testset "$(name)" for (name, build_loss, ref_val, ref_grad) in [
-        (
-            "c .+ W",
-            W -> sum((c .+ W) .^ 2),
-            sum((c .+ W_val) .^ 2),
-            2 .* (c .+ W_val),
-        ),
-        (
-            "W .+ c",
-            W -> sum((W .+ c) .^ 2),
-            sum((W_val .+ c) .^ 2),
-            2 .* (W_val .+ c),
-        ),
-        (
-            "c .- W",
-            W -> sum((c .- W) .^ 2),
-            sum((c .- W_val) .^ 2),
-            -2 .* (c .- W_val),
-        ),
-        (
-            "W .- c",
-            W -> sum((W .- c) .^ 2),
-            sum((W_val .- c) .^ 2),
-            2 .* (W_val .- c),
-        ),
-        (
-            "c .* W",
-            W -> sum((c .* W) .^ 2),
-            sum((c .* W_val) .^ 2),
-            2 * c^2 .* W_val,
-        ),
-        (
-            "W .* c",
-            W -> sum((W .* c) .^ 2),
-            sum((W_val .* c) .^ 2),
-            2 * c^2 .* W_val,
-        ),
+    @testset "$(name)" for (name, expr, ref_mat, dexpr_dW) in [
+        ("scalar .+ M", c .+ W, c .+ W_val, fill(1.0, rows, cols)),
+        ("M .+ scalar", W .+ c, W_val .+ c, fill(1.0, rows, cols)),
+        ("scalar .- M", c .- W, c .- W_val, fill(-1.0, rows, cols)),
+        ("M .- scalar", W .- c, W_val .- c, fill(1.0, rows, cols)),
+        ("scalar .* M", c .* W, c .* W_val, fill(c, rows, cols)),
+        ("M .* scalar", W .* c, W_val .* c, fill(c, rows, cols)),
     ]
-        model = Model()
-        @variable(
-            model,
-            W[1:rows, 1:cols],
-            container = ArrayDiff.ArrayOfVariables,
-        )
-        loss = build_loss(W)
-        mode = ArrayDiff.Mode()
-        ad = ArrayDiff.model(mode)
-        MOI.Nonlinear.set_objective(ad, JuMP.moi_function(loss))
-        evaluator = MOI.Nonlinear.Evaluator(
-            ad,
-            mode,
-            JuMP.index.(JuMP.all_variables(model)),
-        )
-        MOI.initialize(evaluator, [:Grad])
-        @test MOI.eval_objective(evaluator, x) ≈ ref_val
-        g = zero(x)
-        MOI.eval_objective_gradient(evaluator, g, x)
-        @test g ≈ vec(ref_grad)
+        sizes, val, g = _eval(model, LinearAlgebra.norm(expr), x)
+        # Outer norm scalar (k=1), then the broadcast (k=2) which must
+        # inherit the matrix child's (rows, cols) shape — not the old
+        # `(1, 1)` stub — then the two children (one scalar leaf, one
+        # matrix leaf) in some order.
+        @test sizes.ndims[1] == 0
+        @test sizes.ndims[2] == 2
+        b_off = sizes.size_offset[2]
+        @test sizes.size[b_off+1] == rows
+        @test sizes.size[b_off+2] == cols
+        @test 0 in sizes.ndims[3:4]
+        @test val ≈ LinearAlgebra.norm(ref_mat)
+        @test g ≈ vec(dexpr_dW .* ref_mat) ./ LinearAlgebra.norm(ref_mat)
     end
     return
 end

--- a/test/JuMP.jl
+++ b/test/JuMP.jl
@@ -495,6 +495,86 @@ function test_broadcast_scalar_matrix_gradient()
     return
 end
 
+# Cover broadcasting where one operand is a column vector or a row vector
+# (vector-transpose) and the other is the matrix variable W. Same loss shape
+# as `test_broadcast_scalar_matrix_gradient` — `norm(c op W)` — so the
+# analytic gradient is `dexpr_dW .* (c op W) ./ norm(c op W)`.
+function test_broadcast_vector_matrix_gradient()
+    rows, cols = 2, 3
+    model = Model()
+    @variable(model, W[1:rows, 1:cols], container = ArrayDiff.ArrayOfVariables)
+    v = [10.0, 20.0]                  # length-rows column vector
+    r = [100.0 200.0 300.0]           # 1×cols row vector (vector-transpose)
+    x = Float64.(collect(1:(rows*cols)))
+    W_val = reshape(x, rows, cols)
+    # Broadcast partials: `dexpr_dW` is the elementwise ∂(c op W)/∂W,
+    # broadcast to W's (rows, cols) shape.
+    v_bcast = v .* ones(rows, cols)   # repeats v across cols
+    r_bcast = ones(rows) .* r         # repeats r down rows
+    @testset "$(name)" for (name, expr, ref_mat, dexpr_dW) in [
+        # Column-vector broadcast (v repeats across cols)
+        ("v .+ W", v .+ W, v .+ W_val, fill(1.0, rows, cols)),
+        ("W .+ v", W .+ v, W_val .+ v, fill(1.0, rows, cols)),
+        ("v .- W", v .- W, v .- W_val, fill(-1.0, rows, cols)),
+        ("W .- v", W .- v, W_val .- v, fill(1.0, rows, cols)),
+        ("v .* W", v .* W, v .* W_val, v_bcast),
+        ("W .* v", W .* v, W_val .* v, v_bcast),
+        # Row-vector broadcast (r repeats down rows)
+        ("r .+ W", r .+ W, r .+ W_val, fill(1.0, rows, cols)),
+        ("W .+ r", W .+ r, W_val .+ r, fill(1.0, rows, cols)),
+        ("r .- W", r .- W, r .- W_val, fill(-1.0, rows, cols)),
+        ("W .- r", W .- r, W_val .- r, fill(1.0, rows, cols)),
+        ("r .* W", r .* W, r .* W_val, r_bcast),
+        ("W .* r", W .* r, W_val .* r, r_bcast),
+    ]
+        sizes, val, g = _eval(model, LinearAlgebra.norm(expr), x)
+        # Tape: norm (k=1, scalar) then the broadcast (k=2, matrix) inheriting
+        # (rows, cols) from the result shape — not from the smaller operand.
+        @test sizes.ndims[1] == 0
+        @test sizes.ndims[2] == 2
+        b_off = sizes.size_offset[2]
+        @test sizes.size[b_off+1] == rows
+        @test sizes.size[b_off+2] == cols
+        @test val ≈ LinearAlgebra.norm(ref_mat)
+        @test g ≈ vec(dexpr_dW .* ref_mat) ./ LinearAlgebra.norm(ref_mat)
+    end
+    return
+end
+
+# Outer-product-shape broadcast: a vector variable `v` (length rows) combined
+# with a row-vector constant `r` (1×cols). The result is rows×cols, and the
+# gradient w.r.t. v reduces along the broadcasted (cols) dimension.
+function test_broadcast_outer_vector_gradient()
+    rows, cols = 2, 3
+    model = Model()
+    @variable(model, v[1:rows], container = ArrayDiff.ArrayOfVariables)
+    r = [100.0 200.0 300.0]           # 1×cols row vector
+    x = Float64.(collect(1:rows))
+    v_val = copy(x)
+    r_bcast = ones(rows) .* r         # ∂(v .* r)/∂v broadcast to (rows, cols)
+    @testset "$(name)" for (name, expr, ref_mat, dexpr_dv) in [
+        ("v .+ r", v .+ r, v_val .+ r, fill(1.0, rows, cols)),
+        ("r .+ v", r .+ v, r .+ v_val, fill(1.0, rows, cols)),
+        ("v .- r", v .- r, v_val .- r, fill(1.0, rows, cols)),
+        ("r .- v", r .- v, r .- v_val, fill(-1.0, rows, cols)),
+        ("v .* r", v .* r, v_val .* r, r_bcast),
+        ("r .* v", r .* v, r .* v_val, r_bcast),
+    ]
+        sizes, val, g = _eval(model, LinearAlgebra.norm(expr), x)
+        @test sizes.ndims[1] == 0
+        @test sizes.ndims[2] == 2
+        b_off = sizes.size_offset[2]
+        @test sizes.size[b_off+1] == rows
+        @test sizes.size[b_off+2] == cols
+        @test val ≈ LinearAlgebra.norm(ref_mat)
+        # `d norm(M) / d v_i = sum_j dexpr_dv[i,j] * M[i,j] / norm(M)` because
+        # v's column is broadcast across every output column.
+        @test g ≈ vec(sum(dexpr_dv .* ref_mat; dims = 2)) ./
+                  LinearAlgebra.norm(ref_mat)
+    end
+    return
+end
+
 end  # module
 
 TestJuMP.runtests()

--- a/test/JuMP.jl
+++ b/test/JuMP.jl
@@ -184,6 +184,7 @@ function _eval(model::JuMP.GenericModel{T}, func, x) where {T}
     g = zero(x)
     MOI.eval_objective_gradient(evaluator, g, x_grad)
     if VERSION >= v"1.12"
+        fill!(evaluator.backend.last_x, NaN)
         @test 0 == @allocated MOI.eval_objective_gradient(evaluator, g, x_grad)
     end
     MOI.Nonlinear.set_objective(ad, nothing)

--- a/test/JuMP.jl
+++ b/test/JuMP.jl
@@ -177,6 +177,7 @@ function _eval(model::JuMP.GenericModel{T}, func, x) where {T}
     sizes = evaluator.backend.objective.expr.sizes
     val = MOI.eval_objective(evaluator, x)
     if VERSION >= v"1.12"
+        fill!(evaluator.backend.last_x, NaN)
         @test 0 == @allocated MOI.eval_objective(evaluator, x)
     end
     x_grad = T.(collect(1:8))
@@ -569,8 +570,9 @@ function test_broadcast_outer_vector_gradient()
         @test val ≈ LinearAlgebra.norm(ref_mat)
         # `d norm(M) / d v_i = sum_j dexpr_dv[i,j] * M[i,j] / norm(M)` because
         # v's column is broadcast across every output column.
-        @test g ≈ vec(sum(dexpr_dv .* ref_mat; dims = 2)) ./
-                  LinearAlgebra.norm(ref_mat)
+        @test g ≈
+              vec(sum(dexpr_dv .* ref_mat; dims = 2)) ./
+              LinearAlgebra.norm(ref_mat)
     end
     return
 end


### PR DESCRIPTION
We're getting big wins on the benchmark: **20x faster with GPU**
```julia-repl
julia> versioninfo()
Julia Version 1.12.6
Commit 15346901f00 (2026-04-09 19:20 UTC)
Build Info:
  Official https://julialang.org release
Platform Info:
  OS: Linux (x86_64-linux-gnu)
  CPU: 16 × Intel(R) Core(TM) Ultra 7 265H
  WORD_SIZE: 64
  LLVM: libLLVM-18.1.7 (ORCJIT, arrowlake)
  GC: Built with stock GC
Threads: 1 default, 1 interactive, 1 GC (on 16 virtual cores)

julia> CUDA.versioninfo()
CUDA toolchain: 
- runtime 13.2, artifact installation
- driver 595.58.3 for 13.2
- compiler 13.2, artifact installation

CUDA libraries: 
- cuBLAS: 13.4.0
- cuSPARSE: 12.7.10
- cuSOLVER: 12.2.0
- cuFFT: 12.2.0
- cuRAND: 10.4.2
- CUPTI: 2026.1.1 (API 13.2.1)
- NVML: 13.0.0+595.58.3

Julia packages: 
- CUDACore: 6.1.0
- GPUArrays: 11.5.3
- GPUCompiler: 1.9.1
- KernelAbstractions: 0.9.41
- CUDA_Driver_jll: 13.2.1+0
- CUDA_Compiler_jll: 0.4.3+0
- CUDA_Runtime_jll: 0.21.0+1

Toolchain:
- Julia: 1.12.6
- LLVM: 18.1.7

1 device:
  0: NVIDIA RTX PRO 1000 Blackwell Generation Laptop GPU (sm_120, 7.291 GiB / 7.960 GiB available)
```
Before
```
julia> include("perf/arraydiff.jl");

julia> T, h, d, n = Float32, 4096, 13, 178;

julia> ArrayDiffNeural.neural(T, h, d, n; gpu=true)
BenchmarkTools.Trial: 440 samples with 1 evaluation per sample.
 Range (min … max):   9.975 ms … 214.304 ms  ┊ GC (min … max): 0.00% … 44.48%
 Time  (median):     10.808 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   11.370 ms ±   9.709 ms  ┊ GC (mean ± σ):  1.91% ±  2.12%

            ▁▄▅▇█▆▆▃▂                                           
  ▃▁▁▁▂▃▄▃▆██████████▇▇▃▆▃▄▃▃▃▂▃▁▃▂▂▂▂▁▁▂▂▃▁▁▂▁▁▂▂▂▁▂▁▂▁▁▁▁▂▃▂ ▃
  9.97 ms         Histogram: frequency by time         13.3 ms <

 Memory estimate: 210.75 KiB, allocs estimate: 9913.

julia> ArrayDiffNeural.neural(T, h, d, n; gpu=false)
BenchmarkTools.Trial: 449 samples with 1 evaluation per sample.
 Range (min … max):  10.991 ms …  12.391 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     11.085 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   11.150 ms ± 190.100 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

   ▃▅██▇▆▄▄▄▄▂▂                                                 
  ▇█████████████▇▇▇█▄▆▁▆▄▄▄▄▁▄▆▄▆▄▆▄▁▁▄▆▁▁▆▁▇▄▇▁▇▆▁▆▄▆▁▁▁▄▁▁▁▄ ▇
  11 ms         Histogram: log(frequency) by time      11.9 ms <

 Memory estimate: 0 bytes, allocs estimate: 0.
```
After
```
julia> ArrayDiffNeural.neural(T, h, d, n; gpu=true)
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):  446.205 μs …  6.997 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     473.737 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   490.190 μs ± 78.866 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

      ▇█▄                                                       
  ▂▂▃▆███▇▆▅▅▄▄▃▄▆▇▆▅▄▃▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▂ ▃
  446 μs          Histogram: frequency by time          665 μs <

 Memory estimate: 35.16 KiB, allocs estimate: 1139.

julia> ArrayDiffNeural.neural(T, h, d, n; gpu=false)
BenchmarkTools.Trial: 533 samples with 1 evaluation per sample.
 Range (min … max):   5.503 ms … 11.054 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     10.463 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):    9.384 ms ±  1.919 ms  ┊ GC (mean ± σ):  0.00% ± 0.00%

                                                        ▄█▁    
  ▂▂▂▃▃▃▄▃▃▄▃▃▃▂▁▂▁▁▁▁▁▁▁▁▁▁▁▁▁▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁███▅▄ ▂
  5.5 ms          Histogram: frequency by time        10.8 ms <

 Memory estimate: 0 bytes, allocs estimate: 0.
```