### PR TITLE
Implements sum_dims

### DIFF
--- a/src/JuMP/operators.jl
+++ b/src/JuMP/operators.jl
@@ -62,9 +62,48 @@ function Base.broadcasted(
     return Base.broadcasted(^, x, y)
 end
 
-function Base.sum(x::GenericArrayExpr)
+# `sum(x; dims)` reduces `x` along the given dimension(s), preserving the
+# other dimensions. The output keeps the same ndims as the input, with the
+# reduced axes collapsed to size 1 (matching Julia's `Base.sum(; dims)`).
+# With `dims=:` (default), the result is a scalar.
+#
+# The dimensions are encoded as a `Vector{Float64}` so they live in the
+# normal tape-typed `NODE_VALUE_BLOCK` storage — the forward and reverse
+# passes read them back as integers. ArrayDiff tape storage is Float64 only,
+# so this is the natural way to carry them. We do not differentiate the
+# `dims` argument; the forward/reverse handlers assert it's a value block.
+function _sum_dims_expr(::Type{V}, x, dims_tuple::Tuple{Vararg{Int}}) where {V}
+    out = ntuple(i -> i in dims_tuple ? 1 : size(x, i), ndims(x))
+    dims_arr = Float64[Float64(d) for d in dims_tuple]
+    return GenericArrayExpr{V,ndims(x)}(
+        :sum_dims,
+        Any[x, dims_arr],
+        out,
+        false,
+    )
+end
+
+function _scalar_sum(x)
     V = JuMP.variable_ref_type(x)
     return JuMP.GenericNonlinearExpr{V}(:sum, Any[x])
+end
+
+function Base.sum(x::GenericArrayExpr; dims = Colon())
+    if dims === Colon()
+        return _scalar_sum(x)
+    end
+    V = JuMP.variable_ref_type(x)
+    dims_tuple = dims isa Integer ? (Int(dims),) : Tuple(Int(d) for d in dims)
+    return _sum_dims_expr(V, x, dims_tuple)
+end
+
+function Base.sum(x::ArrayOfVariables; dims = Colon())
+    if dims === Colon()
+        return _scalar_sum(x)
+    end
+    V = JuMP.variable_ref_type(x)
+    dims_tuple = dims isa Integer ? (Int(dims),) : Tuple(Int(d) for d in dims)
+    return _sum_dims_expr(V, x, dims_tuple)
 end
 
 import LinearAlgebra

--- a/src/JuMP/operators.jl
+++ b/src/JuMP/operators.jl
@@ -62,48 +62,14 @@ function Base.broadcasted(
     return Base.broadcasted(^, x, y)
 end
 
-# `sum(x; dims)` reduces `x` along the given dimension(s), preserving the
-# other dimensions. The output keeps the same ndims as the input, with the
-# reduced axes collapsed to size 1 (matching Julia's `Base.sum(; dims)`).
-# With `dims=:` (default), the result is a scalar.
-#
-# The dimensions are encoded as a `Vector{Float64}` so they live in the
-# normal tape-typed `NODE_VALUE_BLOCK` storage — the forward and reverse
-# passes read them back as integers. ArrayDiff tape storage is Float64 only,
-# so this is the natural way to carry them. We do not differentiate the
-# `dims` argument; the forward/reverse handlers assert it's a value block.
-function _sum_dims_expr(::Type{V}, x, dims_tuple::Tuple{Vararg{Int}}) where {V}
-    out = ntuple(i -> i in dims_tuple ? 1 : size(x, i), ndims(x))
-    dims_arr = Float64[Float64(d) for d in dims_tuple]
-    return GenericArrayExpr{V,ndims(x)}(
-        :sum_dims,
-        Any[x, dims_arr],
-        out,
-        false,
-    )
-end
-
-function _scalar_sum(x)
+function Base.sum(x::AbstractJuMPArray; dims = Colon())
     V = JuMP.variable_ref_type(x)
-    return JuMP.GenericNonlinearExpr{V}(:sum, Any[x])
-end
-
-function Base.sum(x::GenericArrayExpr; dims = Colon())
     if dims === Colon()
-        return _scalar_sum(x)
+        return JuMP.GenericNonlinearExpr{V}(:sum, Any[x])
     end
-    V = JuMP.variable_ref_type(x)
-    dims_tuple = dims isa Integer ? (Int(dims),) : Tuple(Int(d) for d in dims)
-    return _sum_dims_expr(V, x, dims_tuple)
-end
-
-function Base.sum(x::ArrayOfVariables; dims = Colon())
-    if dims === Colon()
-        return _scalar_sum(x)
-    end
-    V = JuMP.variable_ref_type(x)
-    dims_tuple = dims isa Integer ? (Int(dims),) : Tuple(Int(d) for d in dims)
-    return _sum_dims_expr(V, x, dims_tuple)
+    sz = ntuple(i -> i in dims ? 1 : size(x, i), ndims(x))
+    dims_vec = JuMP.value_type(V)[d for d in dims]
+    return GenericArrayExpr{V,ndims(x)}(:sum_dims, Any[x, dims_vec], sz, false)
 end
 
 import LinearAlgebra

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -18,6 +18,7 @@ const DEFAULT_MULTIVARIATE_OPERATORS = [
     :norm,
     :sum,
     :row,
+    :sum_dims,
 ]
 
 function _validate_register_assumptions(

--- a/src/reverse_mode.jl
+++ b/src/reverse_mode.jl
@@ -365,6 +365,24 @@ function _forward_eval(
                     val = @s f.forward_storage[ix]
                     @j f.forward_storage[k] = val
                 end
+            elseif node.index == 17 # sum_dims
+                # Forward: out_view = sum(in_view; dims=...). Output node
+                # `k` keeps the input ndims with the reduced dims collapsed
+                # to size 1, so `sum!(out_view, in_view)` does it in-place
+                # (Julia's `sum!` uses the destination's size-1 dims as the
+                # reduction axes). The dims arg is a NODE_VALUE_BLOCK; we
+                # don't differentiate it.
+                @assert N == 2 "`sum_dims` expects (array, dims_vector)"
+                arr_ix = children_arr[first(children_indices)]
+                dims_ix = children_arr[first(children_indices)+1]
+                @assert f.nodes[dims_ix].type == NODE_VALUE_BLOCK
+                _reshape_call(
+                    f.forward_storage,
+                    f.sizes,
+                    (k, arr_ix),
+                    sum!,
+                    tuple(),
+                )
             else # atan, min, max
                 f_input = _UnsafeVectorView(d.jac_storage, N)
                 ∇f = _UnsafeVectorView(d.user_output_buffer, N)
@@ -564,6 +582,16 @@ function __reverse_broadcasted_mul(f, ilhs, irhs, dout, dlhs, drhs)
         _reverse_broadcasted_mul,
         (dout, dlhs, drhs),
     )
+end
+
+# Reverse for `sum_dims`: broadcast the parent's gradient back to the
+# input's shape. Parent has size 1 in the reduced dimensions, child has the
+# original input shape — `dchild .= dparent` does the expansion via Julia
+# broadcasting. Called through `_reshape_call` so the views match the
+# input/parent ndims.
+function _reverse_sum_dims!(dchild, dparent)
+    dchild .= dparent
+    return
 end
 
 """
@@ -809,6 +837,26 @@ function _reverse_eval(
                         # partial is 1 so we can ignore it
                         @s f.reverse_storage[ix] = rev_parent_j
                     end
+                    continue
+                elseif op == :sum_dims
+                    # Reverse: every position in the (reduced) parent feeds
+                    # back to every position of the input along the reduced
+                    # dim with partial 1. Because the output keeps the input
+                    # ndims with reduced dims set to 1, a plain broadcast
+                    # `rev_child .= rev_parent` does the expansion for free
+                    # (Julia broadcasts size-1 dims). The `dims` arg is a
+                    # NODE_VALUE_BLOCK; we don't propagate gradient to it.
+                    @assert length(children_indices) == 2 "`sum_dims` expects (array, dims_vector)"
+                    arr_ix = children_arr[first(children_indices)]
+                    dims_ix = children_arr[first(children_indices)+1]
+                    @assert f.nodes[dims_ix].type == NODE_VALUE_BLOCK
+                    _reshape_call(
+                        f.reverse_storage,
+                        f.sizes,
+                        (arr_ix, k),
+                        _reverse_sum_dims!,
+                        tuple(),
+                    )
                     continue
                 end
             end

--- a/src/reverse_mode.jl
+++ b/src/reverse_mode.jl
@@ -365,13 +365,7 @@ function _forward_eval(
                     val = @s f.forward_storage[ix]
                     @j f.forward_storage[k] = val
                 end
-            elseif node.index == 17 # sum_dims
-                # Forward: out_view = sum(in_view; dims=...). Output node
-                # `k` keeps the input ndims with the reduced dims collapsed
-                # to size 1, so `sum!(out_view, in_view)` does it in-place
-                # (Julia's `sum!` uses the destination's size-1 dims as the
-                # reduction axes). The dims arg is a NODE_VALUE_BLOCK; we
-                # don't differentiate it.
+            elseif node.index == 17 # sum_dims -> sum(x; dims)
                 @assert N == 2 "`sum_dims` expects (array, dims_vector)"
                 arr_ix = children_arr[first(children_indices)]
                 dims_ix = children_arr[first(children_indices)+1]
@@ -586,9 +580,8 @@ end
 
 # Reverse for `sum_dims`: broadcast the parent's gradient back to the
 # input's shape. Parent has size 1 in the reduced dimensions, child has the
-# original input shape — `dchild .= dparent` does the expansion via Julia
-# broadcasting. Called through `_reshape_call` so the views match the
-# input/parent ndims.
+# original input shape.
+# Good news: `dchild .= dparent` does the expansion via Julia broadcasting.
 function _reverse_sum_dims!(dchild, dparent)
     dchild .= dparent
     return
@@ -839,13 +832,6 @@ function _reverse_eval(
                     end
                     continue
                 elseif op == :sum_dims
-                    # Reverse: every position in the (reduced) parent feeds
-                    # back to every position of the input along the reduced
-                    # dim with partial 1. Because the output keeps the input
-                    # ndims with reduced dims set to 1, a plain broadcast
-                    # `rev_child .= rev_parent` does the expansion for free
-                    # (Julia broadcasts size-1 dims). The `dims` arg is a
-                    # NODE_VALUE_BLOCK; we don't propagate gradient to it.
                     @assert length(children_indices) == 2 "`sum_dims` expects (array, dims_vector)"
                     arr_ix = children_arr[first(children_indices)]
                     dims_ix = children_arr[first(children_indices)+1]

--- a/src/sizes.jl
+++ b/src/sizes.jl
@@ -342,8 +342,8 @@ end
 function _infer_sizes(
     nodes::Vector{Node},
     adj::SparseArrays.SparseMatrixCSC{Bool,Int},
-    block_shapes::Dict{Int,Vector{Int}} = Dict{Int,Vector{Int}}(),
-    const_values::AbstractVector = Float64[],
+    block_shapes::Dict{Int,Vector{Int}},
+    const_values::AbstractVector, # Needed for sum(_; dims)
 )
     sizes = Sizes(
         zeros(Int, length(nodes)),
@@ -475,13 +475,11 @@ function _infer_sizes(
                 # `block_shapes`.
                 dims_len = prod(block_shapes[dims_id])
                 start = nodes[dims_id].index
-                dims_tuple =
-                    Tuple(Int(const_values[start+i-1]) for i in 1:dims_len)
+                dims_vec = const_values[(start-1) .+ (1:dims_len)]
                 in_ndims = sizes.ndims[arr_id]
-                out_shape =
-                    ntuple(in_ndims) do d
-                        d in dims_tuple ? 1 : _size(sizes, arr_id, d)
-                    end
+                out_shape = map(1:in_ndims) do d
+                    d in dims_vec ? 1 : _size(sizes, arr_id, d)
+                end
                 _add_size!(sizes, k, out_shape)
             else
                 _assert_scalar_children(

--- a/src/sizes.jl
+++ b/src/sizes.jl
@@ -343,6 +343,7 @@ function _infer_sizes(
     nodes::Vector{Node},
     adj::SparseArrays.SparseMatrixCSC{Bool,Int},
     block_shapes::Dict{Int,Vector{Int}} = Dict{Int,Vector{Int}}(),
+    const_values::AbstractVector = Float64[],
 )
     sizes = Sizes(
         zeros(Int, length(nodes)),
@@ -462,6 +463,26 @@ function _infer_sizes(
                     op,
                 )
                 _copy_size!(sizes, k, children_arr[first(children_indices)])
+            elseif op == :sum_dims
+                # Two args: (array, Vector{Float64}(dims)). Output keeps the
+                # input ndims with the reduced dims collapsed to size 1.
+                @assert N == 2 "`sum_dims` expects (array, dims_vector)"
+                arr_id = children_arr[first(children_indices)]
+                dims_id = children_arr[first(children_indices)+1]
+                @assert nodes[dims_id].type == NODE_VALUE_BLOCK "`sum_dims` requires constant dims (NODE_VALUE_BLOCK)"
+                # Read the dims values out of `const_values`. The block was
+                # appended at `nodes[dims_id].index` with length recorded in
+                # `block_shapes`.
+                dims_len = prod(block_shapes[dims_id])
+                start = nodes[dims_id].index
+                dims_tuple =
+                    Tuple(Int(const_values[start+i-1]) for i in 1:dims_len)
+                in_ndims = sizes.ndims[arr_id]
+                out_shape =
+                    ntuple(in_ndims) do d
+                        d in dims_tuple ? 1 : _size(sizes, arr_id, d)
+                    end
+                _add_size!(sizes, k, out_shape)
             else
                 _assert_scalar_children(
                     sizes,
@@ -563,7 +584,7 @@ struct _SubexpressionStorage{T<:Real,S<:AbstractVector{T}}
         linearity::Linearity,
         ::Type{S} = Vector{T},
     ) where {T<:Real,S<:AbstractVector{T}}
-        sizes = _infer_sizes(nodes, adj, block_shapes)
+        sizes = _infer_sizes(nodes, adj, block_shapes, const_values)
         N = _length(sizes)
         # Pre-load value blocks into forward_storage once at construction;
         # each block is a contiguous-to-contiguous bulk copy. Individual

--- a/src/sizes.jl
+++ b/src/sizes.jl
@@ -478,7 +478,7 @@ function _infer_sizes(
                 dims_vec = const_values[(start-1) .+ (1:dims_len)]
                 in_ndims = sizes.ndims[arr_id]
                 out_shape = map(1:in_ndims) do d
-                    d in dims_vec ? 1 : _size(sizes, arr_id, d)
+                    return d in dims_vec ? 1 : _size(sizes, arr_id, d)
                 end
                 _add_size!(sizes, k, out_shape)
             else

--- a/test/JuMP.jl
+++ b/test/JuMP.jl
@@ -720,6 +720,17 @@ function test_transformer_stacked_residual_gradient()
     return _check_transformer_loss(build)
 end
 
+# `sum(x; dims=N)` builds a `:sum_dims` node that reduces along the given
+# dims, keeping the input ndims with the reduced axes collapsed to size 1.
+# Verify both value and gradient against finite differences across
+# `dims=1`, `dims=2`, and `dims=(1,2)` for a 2×3 matrix variable.
+function test_sum_dims_gradient()
+    @testset "dims=$dims" for dims in (1, 2, (1, 2))
+        _check_transformer_loss(x -> sum(sum(x; dims = dims) .^ 2))
+    end
+    return
+end
+
 end  # module
 
 TestJuMP.runtests()


### PR DESCRIPTION
For `sum(x; dims=...)`. It would be better to do something generic for any reduce operation but for now, it's hardcoded for `+`.