### PR TITLE
Avoid computing derivative of constant nodes in matmul

### DIFF
--- a/src/reverse_mode.jl
+++ b/src/reverse_mode.jl
@@ -9,7 +9,7 @@
 # the right view type for each node and `LinearAlgebra.mul!` covers both
 # shape combinations.
 function _matmul_reverse!(f, k::Int, ix1::Int, ix2::Int)
-    if f.nodes[ix1].type != CONSTANT
+    if f.nodes[ix1].type != NODE_VALUE_BLOCK
         _reshape_call(
             f.forward_storage,
             f.sizes,
@@ -18,7 +18,7 @@ function _matmul_reverse!(f, k::Int, ix1::Int, ix2::Int)
             (f.reverse_storage, f.sizes, true, ix1, k),
         )
     end
-    if f.nodes[ix2].type != CONSTANT
+    if f.nodes[ix2].type != NODE_VALUE_BLOCK
         _reshape_call(
             f.forward_storage,
             f.sizes,

--- a/src/reverse_mode.jl
+++ b/src/reverse_mode.jl
@@ -43,7 +43,7 @@ function _matmul_reverse_outer(
         sizes,
         (ix, k),
         _matmul_reverse_inner!,
-        (lhs, v,),
+        (lhs, v),
     )
     return
 end

--- a/src/reverse_mode.jl
+++ b/src/reverse_mode.jl
@@ -9,38 +9,51 @@
 # the right view type for each node and `LinearAlgebra.mul!` covers both
 # shape combinations.
 function _matmul_reverse!(f, k::Int, ix1::Int, ix2::Int)
-    _reshape_call(
-        f.forward_storage,
-        f.sizes,
-        (ix1, ix2),
-        _matmul_reverse_outer,
-        (f.reverse_storage, f.sizes, ix1, ix2, k),
-    )
+    if f.nodes[ix1].type != CONSTANT
+        _reshape_call(
+            f.forward_storage,
+            f.sizes,
+            (ix2,),
+            _matmul_reverse_outer,
+            (f.reverse_storage, f.sizes, false, ix1, k),
+        )
+    end
+    if f.nodes[ix2].type != CONSTANT
+        _reshape_call(
+            f.forward_storage,
+            f.sizes,
+            (ix1,),
+            _matmul_reverse_outer,
+            (f.reverse_storage, f.sizes, true, ix2, k),
+        )
+    end
     return
 end
 
 function _matmul_reverse_outer(
     reverse_storage,
     sizes::Sizes,
-    ix1::Int,
-    ix2::Int,
+    lhs::Bool,
+    ix::Int,
     k::Int,
-    v1,
-    v2,
+    v,
 )
     _reshape_call(
         reverse_storage,
         sizes,
-        (ix1, ix2, k),
+        (ix, k),
         _matmul_reverse_inner!,
-        (v1, v2),
+        (lhs, v,),
     )
     return
 end
 
-function _matmul_reverse_inner!(v1, v2, rev_v1, rev_v2, rev_parent)
-    LinearAlgebra.mul!(rev_v1, rev_parent, transpose(v2))
-    LinearAlgebra.mul!(rev_v2, transpose(v1), rev_parent)
+function _matmul_reverse_inner!(lhs::Bool, v, rev_v, rev_parent)
+    if lhs
+        LinearAlgebra.mul!(rev_v, rev_parent, transpose(v))
+    else
+        LinearAlgebra.mul!(rev_v, transpose(v), rev_parent)
+    end
     return
 end
 

--- a/src/reverse_mode.jl
+++ b/src/reverse_mode.jl
@@ -15,7 +15,7 @@ function _matmul_reverse!(f, k::Int, ix1::Int, ix2::Int)
             f.sizes,
             (ix2,),
             _matmul_reverse_outer,
-            (f.reverse_storage, f.sizes, false, ix1, k),
+            (f.reverse_storage, f.sizes, true, ix1, k),
         )
     end
     if f.nodes[ix2].type != CONSTANT
@@ -24,7 +24,7 @@ function _matmul_reverse!(f, k::Int, ix1::Int, ix2::Int)
             f.sizes,
             (ix1,),
             _matmul_reverse_outer,
-            (f.reverse_storage, f.sizes, true, ix2, k),
+            (f.reverse_storage, f.sizes, false, ix2, k),
         )
     end
     return


### PR DESCRIPTION
## On GPU

Before
```
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):  448.389 μs …  10.186 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     471.410 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   485.842 μs ± 103.175 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

      ▁▆█▆▂                                                      
  ▁▁▂▄█████▇▅▄▃▃▃▃▂▂▂▃▄▅▇▆▅▄▃▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▂
  448 μs           Histogram: frequency by time          607 μs <

 Memory estimate: 35.03 KiB, allocs estimate: 1139.
```
After
```
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):  366.680 μs …  7.760 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     389.702 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   396.722 μs ± 79.007 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

            ▁▄▇█▆▅▃▁                                            
  ▁▁▂▂▂▂▃▄▅▆█████████▆▅▄▃▃▂▂▂▂▂▂▂▂▂▂▂▁▂▂▂▂▂▂▂▂▂▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁ ▃
  367 μs          Histogram: frequency by time          459 μs <

 Memory estimate: 32.31 KiB, allocs estimate: 1045.
```