### PR TITLE
Eval network until the end for fairness

### DIFF
--- a/perf/hand_cuda.jl
+++ b/perf/hand_cuda.jl
@@ -31,9 +31,11 @@ const OUT_DIM = 2
 struct Buffers{M<:AbstractMatrix}
     y_1::M      # h × n   = tanh.(W1 * X)
     J_1::M      # h × n   = 1 .- y_1.^2
-    J_2::M      # m × n   = 2 .* (W2*y_1 .- y)
+    J_2::M      # m × n   = W2*y_1 - y, then scaled in place by 2
     W2T_J2::M   # h × n   = W2' * J_2, then ⊙= J_1
     grad::M     # h × d   = W2T_J2 * X'
+    loss::M     # 1 × 1   = sum((W2*y_1 - y).^2), kept on-device to match
+                #         `arraydiff.jl`'s `forward_storage[1]`
 end
 
 function Buffers{M}(h::Int, d::Int, n::Int) where {M}
@@ -43,6 +45,7 @@ function Buffers{M}(h::Int, d::Int, n::Int) where {M}
         M(undef, OUT_DIM, n),
         M(undef, h, n),
         M(undef, h, d),
+        M(undef, 1, 1),
     )
 end
 
@@ -51,11 +54,16 @@ function gradient!(buf::Buffers, W1, W2, X, y)
     buf.y_1 .= tanh.(buf.y_1)                     # y_1 = tanh.(y_1)
     buf.J_1 .= 1 .- buf.y_1 .^ 2
     LinearAlgebra.mul!(buf.J_2, W2, buf.y_1)
-    buf.J_2 .= 2 .* (buf.J_2 .- y)
+    buf.J_2 .-= y                                 # J_2 = residual (W2*y_1 - y)
+    # Fold the squaring into the reduction kernel so we don't materialise an
+    # extra (m × n) temporary. Result stays on device — ArrayDiff's tape leaves
+    # `forward_storage[1]` untouched on the device too.
+    Base.sum!(buf.loss, buf.J_2 .^ 2)
+    buf.J_2 .*= 2                                 # J_2 = 2 * residual = dL/dY
     LinearAlgebra.mul!(buf.W2T_J2, W2', buf.J_2)
     buf.W2T_J2 .= buf.J_1 .* buf.W2T_J2
     LinearAlgebra.mul!(buf.grad, buf.W2T_J2, X')
-    return buf.grad
+    return buf.loss, buf.grad
 end
 
 # Allocating reverse pass — same arithmetic, but every intermediate is a
@@ -64,8 +72,10 @@ end
 function gradient_alloc(W1, W2, X, y)
     y_1 = tanh.(W1 * X)
     J_1 = 1 .- y_1 .^ 2
-    J_2 = 2 .* (W2 * y_1 .- y)
-    return (J_1 .* (W2' * J_2)) * X'
+    residual = W2 * y_1 .- y
+    loss = sum(abs2, residual)
+    J_2 = 2 .* residual
+    return loss, (J_1 .* (W2' * J_2)) * X'
 end
 
 """

--- a/perf/hand_cuda.jl
+++ b/perf/hand_cuda.jl
@@ -35,7 +35,7 @@ struct Buffers{M<:AbstractMatrix}
     W2T_J2::M   # h × n   = W2' * J_2, then ⊙= J_1
     grad::M     # h × d   = W2T_J2 * X'
     loss::M     # 1 × 1   = sum((W2*y_1 - y).^2), kept on-device to match
-                #         `arraydiff.jl`'s `forward_storage[1]`
+    #         `arraydiff.jl`'s `forward_storage[1]`
 end
 
 function Buffers{M}(h::Int, d::Int, n::Int) where {M}


### PR DESCRIPTION
The others were evaluating the network completely, not just the gradient so it's fairer to do it in hand-cuda too.
Still the fastest though:
```julia-repl
julia> HandCuda.neural(T, h, d, n; prealloc=false, gpu=false)
BenchmarkTools.Trial: 316 samples with 1 evaluation per sample.
 Range (min … max):   8.493 ms … 267.355 ms  ┊ GC (min … max):  0.00% … 96.10%
 Time  (median):      8.758 ms               ┊ GC (median):     0.00%
 Time  (mean ± σ):   15.838 ms ±  37.459 ms  ┊ GC (mean ± σ):  41.13% ± 18.44%

  █▂                                                            
  ██▄▁▁▁▄▆▅▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▆ ▅
  8.49 ms       Histogram: log(frequency) by time       261 ms <

 Memory estimate: 14.11 MiB, allocs estimate: 25.

julia> HandCuda.neural(T, h, d, n; prealloc=true, gpu=false)
BenchmarkTools.Trial: 424 samples with 1 evaluation per sample.
 Range (min … max):   4.810 ms … 284.633 ms  ┊ GC (min … max):  0.00% … 96.84%
 Time  (median):      8.260 ms               ┊ GC (median):     0.00%
 Time  (mean ± σ):   12.432 ms ±  32.054 ms  ┊ GC (mean ± σ):  35.17% ± 15.16%

  █▄                                                            
  ██▁▁▁▁▁▆▅▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄▄ ▆
  4.81 ms       Histogram: log(frequency) by time       274 ms <

 Memory estimate: 8.55 MiB, allocs estimate: 19.

julia> HandCuda.neural(T, h, d, n; prealloc=false, gpu=true)
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):  215.534 μs … 286.947 ms  ┊ GC (min … max):  0.00% … 96.67%
 Time  (median):     225.652 μs               ┊ GC (median):     0.00%
 Time  (mean ± σ):   293.689 μs ±   2.987 ms  ┊ GC (mean ± σ):  14.14% ±  1.92%

       ▂█▅▁                                                      
  ▁▁▁▃▆████▇▅▄▄▃▂▂▃▃▂▂▂▂▂▂▁▂▂▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▂
  216 μs           Histogram: frequency by time          291 μs <

 Memory estimate: 16.48 KiB, allocs estimate: 526.

julia> HandCuda.neural(T, h, d, n; prealloc=true, gpu=true)
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):  186.499 μs …  21.708 ms  ┊ GC (min … max): 0.00% … 28.60%
 Time  (median):     195.751 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   222.872 μs ± 664.189 μs  ┊ GC (mean ± σ):  3.47% ±  1.16%

        ▂▄▆█▂                                                    
  ▁▂▂▃▄▇█████▆▅▅▃▃▃▃▃▂▂▂▂▂▂▂▃▃▂▃▃▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▂
  186 μs           Histogram: frequency by time          244 μs <

 Memory estimate: 16.38 KiB, allocs estimate: 488.
```