### PR TITLE
Remove the need for allowscalar

### DIFF
--- a/perf/arraydiff.jl
+++ b/perf/arraydiff.jl
@@ -90,11 +90,7 @@ function neural(
     return @benchmark(
         begin
             if $gpu
-                MOI.eval_objective_gradient(
-                    $state.evaluator,
-                    $g,
-                    $x,
-                )
+                MOI.eval_objective_gradient($state.evaluator, $g, $x)
                 CUDA.synchronize()
             else
                 MOI.eval_objective_gradient($state.evaluator, $g, $x)
@@ -109,11 +105,7 @@ function profile_gpu(; T = Float32, h = 4096, d = 13, n = 178)
     x = CUDA.CuVector{T}(vec(state.W1))
     g = CUDA.zeros(T, h * d)
     fill!(state.evaluator.backend.last_x, NaN)
-    CUDA.@sync MOI.eval_objective_gradient(
-        state.evaluator,
-        g,
-        x,
-    )
+    CUDA.@sync MOI.eval_objective_gradient(state.evaluator, g, x)
     fill!(state.evaluator.backend.last_x, NaN)
     return CUDA.@profile CUDA.@sync MOI.eval_objective_gradient(
         state.evaluator,

--- a/perf/arraydiff.jl
+++ b/perf/arraydiff.jl
@@ -68,10 +68,10 @@ trial; the timed block is just `MOI.eval_objective_gradient` plus a
 `CUDA.synchronize` when `gpu=true`.
 """
 function neural(
-    ::Type{T},
-    h::Int,
-    d::Int,
-    n::Int;
+    ::Type{T} = Float32,
+    h::Int = 4096,
+    d::Int = 13,
+    n::Int = 178;
     gpu::Bool = false,
 ) where {T<:Real}
     state = _build(T, h, d, n, gpu)
@@ -90,9 +90,7 @@ function neural(
     return @benchmark(
         begin
             if $gpu
-                # `@allowscalar` covers residual scalar leaves the BLOCK
-                # rewrite can't fold; the hot path is bulk.
-                CUDA.@allowscalar MOI.eval_objective_gradient(
+                MOI.eval_objective_gradient(
                     $state.evaluator,
                     $g,
                     $x,
@@ -111,13 +109,13 @@ function profile_gpu(; T = Float32, h = 4096, d = 13, n = 178)
     x = CUDA.CuVector{T}(vec(state.W1))
     g = CUDA.zeros(T, h * d)
     fill!(state.evaluator.backend.last_x, NaN)
-    CUDA.@sync CUDA.@allowscalar MOI.eval_objective_gradient(
+    CUDA.@sync MOI.eval_objective_gradient(
         state.evaluator,
         g,
         x,
     )
     fill!(state.evaluator.backend.last_x, NaN)
-    return CUDA.@profile CUDA.@sync CUDA.@allowscalar MOI.eval_objective_gradient(
+    return CUDA.@profile CUDA.@sync MOI.eval_objective_gradient(
         state.evaluator,
         g,
         x,

--- a/src/mathoptinterface_api.jl
+++ b/src/mathoptinterface_api.jl
@@ -256,8 +256,10 @@ end
 # Forward-evaluate subexpressions and the residual at `x`.
 function _forward_pass_residual!(d::NLPEvaluator, x)
     for k in d.subexpression_order
+        _forward_eval(d.subexpressions[k], d, x)
+        # FIXME this assumes scalar output
         d.subexpression_forward_values[k] =
-            _forward_eval(d.subexpressions[k], d, x)
+            d.subexpressions[k].forward_storage[1]
     end
     _forward_eval(something(d.residual).expr, d, x)
     return

--- a/src/reverse_mode.jl
+++ b/src/reverse_mode.jl
@@ -94,7 +94,8 @@ function _reverse_mode(d::NLPEvaluator, x)
     for k in d.subexpression_order
         _forward_eval(d.subexpressions[k], d, x)
         # FIXME this assumes scalar output
-        d.subexpression_forward_values[k] = d.subexpressions[k].forward_storage[1]
+        d.subexpression_forward_values[k] =
+            d.subexpressions[k].forward_storage[1]
     end
     if d.objective !== nothing
         _forward_eval(something(d.objective).expr, d, x)

--- a/src/reverse_mode.jl
+++ b/src/reverse_mode.jl
@@ -92,8 +92,9 @@ function _reverse_mode(d::NLPEvaluator, x)
     end
     # Phase I
     for k in d.subexpression_order
-        d.subexpression_forward_values[k] =
-            _forward_eval(d.subexpressions[k], d, x)
+        _forward_eval(d.subexpressions[k], d, x)
+        # FIXME this assumes scalar output
+        d.subexpression_forward_values[k] = d.subexpressions[k].forward_storage[1]
     end
     if d.objective !== nothing
         _forward_eval(something(d.objective).expr, d, x)
@@ -158,7 +159,7 @@ function _forward_eval(
     f::_SubexpressionStorage,
     d::NLPEvaluator,
     x::AbstractVector{T},
-)::T where {T}
+) where {T}
     @assert length(f.forward_storage) >= length(f.nodes)
     @assert length(f.partials_storage) >= length(f.nodes)
     operators = d.data.operators
@@ -633,10 +634,7 @@ function _forward_eval(
             f.partials_storage[rhs] = zero(T)
         end
     end
-    # Caller is responsible for reading the right range of `f.forward_storage`
-    # for vector-valued roots (use `_storage_range(f.sizes, 1)`); the scalar
-    # return is only meaningful when the root is scalar.
-    return f.forward_storage[1]
+    return
 end
 
 """
@@ -823,9 +821,9 @@ Reverse-mode evaluation of an expression tree given in `f`.
  * This function assumes that `f.reverse_storage` has been initialized with 0.0.
 """
 function _reverse_eval(
-    f::_SubexpressionStorage,
-    seed::Union{Nothing,AbstractVector{Float64}} = nothing,
-)
+    f::_SubexpressionStorage{T},
+    seed::Union{Nothing,AbstractVector{T}} = nothing,
+) where {T}
     @assert length(f.reverse_storage) >= _length(f.sizes)
     @assert length(f.partials_storage) >= _length(f.sizes)
     # f.nodes is already in order such that parents always appear before
@@ -834,14 +832,10 @@ function _reverse_eval(
     children_arr = SparseArrays.rowvals(f.adj)
     root_range = _storage_range(f.sizes, 1)
     if seed === nothing
-        for i in root_range
-            f.reverse_storage[i] = one(Float64)
-        end
+        f.reverse_storage[root_range] .= one(T)
     else
         @assert length(seed) == length(root_range)
-        for (j, i) in enumerate(root_range)
-            f.reverse_storage[i] = seed[j]
-        end
+        f.reverse_storage[root_range] .= seed
     end
     for k in 1:length(f.nodes)
         node = f.nodes[k]
@@ -1108,17 +1102,20 @@ function _reverse_eval(
                     elseif op == :^
                         # We start with just .^2 to simplify
                         @assert f.sizes.ndims[rhs] == 0 "Broadcasted ^ requires scalar exponent"
-                        exp = _getscalar(f.forward_storage, f.sizes, rhs)
-                        # To simplify, so we don't need to compute its derivative
+                        # If it is a constant, we can just read it from the `const_values` and avoid a GPU->CPU communication
+                        # We also don't need to compute its derivative
+                        @assert f.nodes[rhs].type == NODE_VALUE
+                        exponent = f.const_values[f.nodes[rhs].index]
+
                         @assert f.nodes[rhs].type == NODE_VALUE
                         rev_parent = _view_linear(f.reverse_storage, f.sizes, k)
                         rev_child =
                             _view_linear(f.reverse_storage, f.sizes, lhs)
-                        if exp == 2
+                        if exponent == 2
                             child =
                                 _view_linear(f.forward_storage, f.sizes, lhs)
                             rev_child .= 2 .* child .* rev_parent
-                        elseif exp == 1
+                        elseif exponent == 1
                             rev_child .= rev_parent
                         else
                             partial =

--- a/test/Optimisers_GPU.jl
+++ b/test/Optimisers_GPU.jl
@@ -50,11 +50,7 @@ function test_neural_optimisers_gpu()
     @objective(model, Min, loss)
     set_attribute(model, "max_iter", 20_000)
     set_attribute(model, "tol", 1e-6)
-    # The variable-load and gradient-extract paths still do scalar reads/writes
-    # against the GPU-resident tape (forward_storage, reverse_storage). Those
-    # are what `@allowscalar` permits. They will be batched in a follow-up;
-    # for now this test is a correctness check, not a performance benchmark.
-    CUDA.@allowscalar optimize!(model)
+    optimize!(model)
     @test objective_value(model) < 1e-3
     return
 end


### PR DESCRIPTION
Something fun, I noticed that adding debug printing to the code was making it faster, and it has no effect now after this PR.
This was because, before this PR, the scalar access were forcing the cpu to wait the gpu to synchronize. Our hypothesis with Claude is that, by doing this printing, it would arrive at a state where the gpu was already ready so no need to way. And without the synchronization, it would need to wait and the cost of waiting would somehow exceed the time taken to do the printing.

Before
```
julia --project=perf perf/gpu_bench.jl
Precompiling ArrayDiff finished.
  1 dependency successfully precompiled in 5 seconds. 53 already precompiled.
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):  242.748 μs …  6.517 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     355.868 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   341.301 μs ± 81.345 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

    ▂▅                                ▃██▅▁                     
  ▂▃██▆▃▂▂▂▂▂▂▂▂▂▂▁▂▂▁▁▂▁▁▁▁▁▁▂▁▂▁▂▃▄▆█████▆▅▄▃▃▃▃▃▄▄▄▄▃▃▃▂▂▂▂ ▃
  243 μs          Histogram: frequency by time          421 μs <

 Memory estimate: 31.61 KiB, allocs estimate: 1004.
Profiler ran for 31.12 ms, capturing 1264 events.

Host-side activity: calling CUDA APIs took 555.99 µs (1.79% of the trace)
┌──────────┬────────────┬───────┬───────────────────────────────────────┬──────────────────────────────────────────────────────┐
│ Time (%) │ Total time │ Calls │ Time distribution                     │ Name                                                 │
├──────────┼────────────┼───────┼───────────────────────────────────────┼──────────────────────────────────────────────────────┤
│    0.43% │   132.8 µs │    14 │   9.49 µs ± 13.8   (  4.77 ‥ 57.22)   │ cuLaunchKernelEx                                     │
│    0.21% │    63.9 µs │     4 │  15.97 µs ± 10.82  (  9.06 ‥ 31.95)   │ cuMemcpyDtoHAsync                                    │
│    0.15% │    45.3 µs │    11 │   4.12 µs ± 6.19   (  1.43 ‥ 22.65)   │ cuMemAllocFromPoolAsync                              │
│    0.13% │   41.48 µs │     9 │   4.61 µs ± 1.52   (   3.1 ‥ 8.11)    │ cuMemcpyHtoDAsync                                    │
│    0.10% │   30.76 µs │     4 │   7.69 µs ± 5.14   (  3.81 ‥ 15.26)   │ cuMemsetD32Async                                     │
│    0.07% │   21.46 µs │     2 │  10.73 µs ± 3.03   (  8.58 ‥ 12.87)   │ cuMemcpyDtoDAsync                                    │
│    0.06% │   18.84 µs │     3 │   6.28 µs ± 1.85   (  4.77 ‥ 8.34)    │ cuLaunchKernel                                       │
│    0.04% │   11.21 µs │     9 │   1.25 µs ± 1.18   (  0.48 ‥ 4.29)    │ cuStreamSynchronize                                  │
│    0.03% │    8.82 µs │     1 │                                       │ cudaLaunchKernelExC                                  │
│    0.02% │    7.63 µs │     1 │                                       │ cudaLaunchKernel                                     │
│    0.02% │    4.77 µs │     8 │ 596.05 ns ± 845.34 (   0.0 ‥ 2622.6)  │ cudaGetLastError                                     │
│    0.01% │    4.29 µs │     1 │                                       │ cudaEventRecord                                      │
│    0.01% │     3.1 µs │     3 │   1.03 µs ± 0.55   (  0.72 ‥ 1.67)    │ cuKernelGetFunction                                  │
│    0.01% │    2.62 µs │     3 │  874.2 ns ± 902.64 (238.42 ‥ 1907.35) │ cudaGetDevice                                        │
│    0.01% │    1.91 µs │     3 │ 635.78 ns ± 364.19 (238.42 ‥ 953.67)  │ cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags │
│    0.01% │    1.91 µs │     3 │ 635.78 ns ± 137.65 (476.84 ‥ 715.26)  │ cudaDeviceGetAttribute                               │
│    0.00% │    1.43 µs │     4 │ 357.63 ns ± 238.42 (238.42 ‥ 715.26)  │ cuCtxPushCurrent                                     │
│    0.00% │  953.67 ns │     4 │ 238.42 ns ± 0.0    (238.42 ‥ 238.42)  │ cuCtxPopCurrent                                      │
│    0.00% │  715.26 ns │     1 │                                       │ cuKernelGetName                                      │
│    0.00% │  715.26 ns │     4 │ 178.81 ns ± 119.21 (   0.0 ‥ 238.42)  │ cuCtxGetDevice                                       │
│    0.00% │  476.84 ns │     4 │ 119.21 ns ± 238.42 (   0.0 ‥ 476.84)  │ cuDeviceGet                                          │
└──────────┴────────────┴───────┴───────────────────────────────────────┴──────────────────────────────────────────────────────┘

Device-side activity: GPU was busy for 146.15 µs (0.47% of the trace)
┌──────────┬────────────┬───────┬──────────────────────────────────────┬────────────────────────────────────────────────────────────────────
│ Time (%) │ Total time │ Calls │ Time distribution                    │ Name                                                              ⋯
├──────────┼────────────┼───────┼──────────────────────────────────────┼────────────────────────────────────────────────────────────────────
│    0.08% │   25.75 µs │     1 │                                      │ void cutlass::Kernel2<cutlass_80_simt_sgemm_32x128_8x5_nn_align1> ⋯
│    0.06% │   17.64 µs │     1 │                                      │ gpu_broadcast_kernel_linear(CompilerMetadata<DynamicSize, Dynamic ⋯
│    0.06% │   17.64 µs │     1 │                                      │ void magma_sgemmEx_kernel<float, float, float, true, false, 6, 4, ⋯
│    0.04% │   13.11 µs │     1 │                                      │ gpu_broadcast_kernel_linear(CompilerMetadata<DynamicSize, Dynamic ⋯
│    0.04% │   11.92 µs │     1 │                                      │ void cutlass::Kernel2<cutlass_80_simt_sgemm_128x32_8x5_nt_align1> ⋯
│    0.04% │   11.21 µs │     1 │                                      │ void cutlass::Kernel2<cutlass_80_simt_sgemm_128x32_8x5_nn_align1> ⋯
│    0.04% │   10.97 µs │     1 │                                      │ gpu_broadcast_kernel_linear(CompilerMetadata<DynamicSize, Dynamic ⋯
│    0.03% │     9.3 µs │     4 │   2.32 µs ± 3.39   (  0.48 ‥ 7.39)   │ [set device memory]                                               ⋯
│    0.02% │    4.77 µs │     1 │                                      │ partial_mapreduce_grid(identity, reducer, NamedTuple<__is_missing ⋯
│    0.01% │    4.53 µs │     4 │   1.13 µs ± 0.12   (  0.95 ‥ 1.19)   │ [copy device to pageable memory]                                  ⋯
│    0.01% │    2.62 µs │     2 │   1.31 µs ± 0.17   (  1.19 ‥ 1.43)   │ [copy device to device memory]                                    ⋯
│    0.01% │    2.38 µs │     1 │                                      │ partial_mapreduce_grid(identity, reducer, NamedTuple<__is_missing ⋯
│    0.01% │    1.91 µs │     1 │                                      │ partial_mapreduce_grid(identity, add_sum, void, CartesianIndices< ⋯
│    0.01% │    1.91 µs │     9 │ 211.93 ns ± 143.27 (   0.0 ‥ 476.84) │ [copy pageable to device memory]                                  ⋯
│    0.01% │    1.91 µs │     1 │                                      │ partial_mapreduce_grid(_, add_sum, Float32, CartesianIndices<2, T ⋯
│    0.01% │    1.67 µs │     1 │                                      │ void cublasLt::splitKreduce_kernel<32, 16, int, float, float, flo ⋯
│    0.00% │    1.43 µs │     1 │                                      │ partial_mapreduce_grid(identity, add_sum, Float32, CartesianIndic ⋯
│    0.00% │    1.43 µs │     1 │                                      │ gpu_broadcast_kernel_linear(CompilerMetadata<DynamicSize, Dynamic ⋯
│    0.00% │  953.67 ns │     1 │                                      │ gpu_broadcast_kernel_linear(CompilerMetadata<DynamicSize, Dynamic ⋯
│    0.00% │  953.67 ns │     1 │                                      │ gpu_broadcast_kernel_cartesian(CompilerMetadata<DynamicSize, Dyna ⋯
│    0.00% │  953.67 ns │     1 │                                      │ gpu_broadcast_kernel_cartesian(CompilerMetadata<DynamicSize, Dyna ⋯
│    0.00% │  715.26 ns │     1 │                                      │ gpu_broadcast_kernel_linear(CompilerMetadata<DynamicSize, Dynamic ⋯
│    0.00% │  476.84 ns │     1 │                                      │ gpu_broadcast_kernel_linear(CompilerMetadata<DynamicSize, Dynamic ⋯
└──────────┴────────────┴───────┴──────────────────────────────────────┴────────────────────────────────────────────────────────────────────
```
After
```
$ julia --project=perf perf/gpu_bench.jl
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):  226.312 μs …  4.894 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     239.389 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   266.470 μs ± 67.781 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

   ▄▇██▇▆▄▃▂▃▃▃▃▂▂                     ▁▂▄▅▅▅▄▃▂▂▁▁▁ ▁▁▁▂▂▁▁▁  ▃
  ▅████████████████▆▆▅▆▁▄▅▄▁▁▁▃▅▃▁▅▄▄▅███████████████████████▇ █
  226 μs        Histogram: log(frequency) by time       379 μs <

 Memory estimate: 31.97 KiB, allocs estimate: 1004.
Profiler ran for 12.53 ms, capturing 1316 events.

Host-side activity: calling CUDA APIs took 617.5 µs (4.93% of the trace)
┌──────────┬────────────┬───────┬───────────────────────────────────────┬──────────────────────────────────────────────────────┐
│ Time (%) │ Total time │ Calls │ Time distribution                     │ Name                                                 │
├──────────┼────────────┼───────┼───────────────────────────────────────┼──────────────────────────────────────────────────────┤
│    1.29% │  162.12 µs │    15 │  10.81 µs ± 18.5   (  4.77 ‥ 77.49)   │ cuLaunchKernelEx                                     │
│    0.49% │   61.51 µs │     2 │  30.76 µs ± 23.27  ( 14.31 ‥ 47.21)   │ cuMemcpyDtoHAsync                                    │
│    0.35% │   44.11 µs │    11 │   4.01 µs ± 5.05   (  1.67 ‥ 19.07)   │ cuMemAllocFromPoolAsync                              │
│    0.34% │    42.2 µs │     4 │  10.55 µs ± 9.31   (  4.05 ‥ 24.32)   │ cuMemsetD32Async                                     │
│    0.30% │   37.67 µs │     8 │   4.71 µs ± 1.37   (   3.1 ‥ 7.39)    │ cuMemcpyHtoDAsync                                    │
│    0.21% │    26.7 µs │     2 │  13.35 µs ± 4.05   ( 10.49 ‥ 16.21)   │ cuMemcpyDtoDAsync                                    │
│    0.17% │   20.98 µs │     3 │   6.99 µs ± 1.62   (  5.72 ‥ 8.82)    │ cuLaunchKernel                                       │
│    0.08% │   10.01 µs │     1 │                                       │ cudaLaunchKernelExC                                  │
│    0.07% │    8.58 µs │     1 │                                       │ cudaLaunchKernel                                     │
│    0.06% │    8.11 µs │     5 │   1.62 µs ± 1.38   (  0.72 ‥ 4.05)    │ cuStreamSynchronize                                  │
│    0.04% │    4.53 µs │     8 │ 566.24 ns ± 583.13 (   0.0 ‥ 1907.35) │ cudaGetLastError                                     │
│    0.03% │    4.29 µs │     1 │                                       │ cudaEventRecord                                      │
│    0.03% │    3.81 µs │     3 │   1.27 µs ± 0.73   (  0.48 ‥ 1.91)    │ cuKernelGetFunction                                  │
│    0.02% │    2.86 µs │     3 │ 953.67 ns ± 825.91 (476.84 ‥ 1907.35) │ cudaGetDevice                                        │
│    0.01% │    1.67 µs │     4 │ 417.23 ns ± 357.63 (238.42 ‥ 953.67)  │ cuCtxPushCurrent                                     │
│    0.01% │    1.67 µs │     3 │ 556.31 ns ± 137.65 (476.84 ‥ 715.26)  │ cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags │
│    0.01% │    1.43 µs │     3 │ 476.84 ns ± 0.0    (476.84 ‥ 476.84)  │ cudaDeviceGetAttribute                               │
│    0.01% │  715.26 ns │     4 │ 178.81 ns ± 228.27 (   0.0 ‥ 476.84)  │ cuCtxPopCurrent                                      │
│    0.01% │  715.26 ns │     4 │ 178.81 ns ± 119.21 (   0.0 ‥ 238.42)  │ cuCtxGetDevice                                       │
│    0.00% │  476.84 ns │     1 │                                       │ cuKernelGetName                                      │
│    0.00% │  476.84 ns │     4 │ 119.21 ns ± 238.42 (   0.0 ‥ 476.84)  │ cuDeviceGet                                          │
└──────────┴────────────┴───────┴───────────────────────────────────────┴──────────────────────────────────────────────────────┘

Device-side activity: GPU was busy for 145.2 µs (1.16% of the trace)
┌──────────┬────────────┬───────┬──────────────────────────────────────┬────────────────────────────────────────────────────────────────────
│ Time (%) │ Total time │ Calls │ Time distribution                    │ Name                                                              ⋯
├──────────┼────────────┼───────┼──────────────────────────────────────┼────────────────────────────────────────────────────────────────────
│    0.21% │   25.75 µs │     1 │                                      │ void cutlass::Kernel2<cutlass_80_simt_sgemm_32x128_8x5_nn_align1> ⋯
│    0.14% │   18.12 µs │     1 │                                      │ void magma_sgemmEx_kernel<float, float, float, true, false, 6, 4, ⋯
│    0.14% │   17.64 µs │     1 │                                      │ gpu_broadcast_kernel_linear(CompilerMetadata<DynamicSize, Dynamic ⋯
│    0.11% │   13.35 µs │     1 │                                      │ gpu_broadcast_kernel_linear(CompilerMetadata<DynamicSize, Dynamic ⋯
│    0.10% │   11.92 µs │     1 │                                      │ void cutlass::Kernel2<cutlass_80_simt_sgemm_128x32_8x5_nt_align1> ⋯
│    0.09% │   11.21 µs │     1 │                                      │ gpu_broadcast_kernel_linear(CompilerMetadata<DynamicSize, Dynamic ⋯
│    0.09% │   10.97 µs │     1 │                                      │ void cutlass::Kernel2<cutlass_80_simt_sgemm_128x32_8x5_nn_align1> ⋯
│    0.08% │    9.54 µs │     4 │   2.38 µs ± 3.5    (  0.48 ‥ 7.63)   │ [set device memory]                                               ⋯
│    0.03% │    4.05 µs │     1 │                                      │ partial_mapreduce_grid(identity, reducer, NamedTuple<__is_missing ⋯
│    0.03% │    3.81 µs │     2 │   1.91 µs ± 0.34   (  1.67 ‥ 2.15)   │ [copy device to pageable memory]                                  ⋯
│    0.02% │    2.38 µs │     1 │                                      │ partial_mapreduce_grid(identity, reducer, NamedTuple<__is_missing ⋯
│    0.02% │    2.15 µs │     2 │   1.07 µs ± 0.17   (  0.95 ‥ 1.19)   │ [copy device to device memory]                                    ⋯
│    0.02% │    1.91 µs │     1 │                                      │ void cublasLt::splitKreduce_kernel<32, 16, int, float, float, flo ⋯
│    0.02% │    1.91 µs │     8 │ 238.42 ns ± 0.0    (238.42 ‥ 238.42) │ [copy pageable to device memory]                                  ⋯
│    0.01% │    1.67 µs │     1 │                                      │ partial_mapreduce_grid(identity, add_sum, void, CartesianIndices< ⋯
│    0.01% │    1.67 µs │     1 │                                      │ partial_mapreduce_grid(_, add_sum, Float32, CartesianIndices<2, T ⋯
│    0.01% │    1.43 µs │     1 │                                      │ partial_mapreduce_grid(identity, add_sum, Float32, CartesianIndic ⋯
│    0.01% │    1.43 µs │     1 │                                      │ gpu_broadcast_kernel_linear(CompilerMetadata<DynamicSize, Dynamic ⋯
│    0.01% │  953.67 ns │     1 │                                      │ gpu_broadcast_kernel_linear(CompilerMetadata<DynamicSize, Dynamic ⋯
│    0.01% │  953.67 ns │     1 │                                      │ gpu_broadcast_kernel_cartesian(CompilerMetadata<DynamicSize, Dyna ⋯
│    0.01% │  715.26 ns │     1 │                                      │ gpu_broadcast_kernel_linear(CompilerMetadata<DynamicSize, Dynamic ⋯
│    0.01% │  715.26 ns │     1 │                                      │ gpu_broadcast_kernel_cartesian(CompilerMetadata<DynamicSize, Dyna ⋯
│    0.00% │  476.84 ns │     1 │                                      │ gpu_broadcast_kernel_linear(CompilerMetadata<DynamicSize, Dynamic ⋯
│    0.00% │  476.84 ns │     1 │                                      │ gpu_broadcast_kernel_linear(CompilerMetadata<DynamicSize, Dynamic ⋯
└──────────┴────────────┴───────┴──────────────────────────────────────┴────────────────────────────────────────────────────────────────────
```